### PR TITLE
mandatory JudoID for card Registration + extension of 3dSecure Viewmodel

### DIFF
--- a/JudoPayDotNet/Clients/BaseRegisterCards.cs
+++ b/JudoPayDotNet/Clients/BaseRegisterCards.cs
@@ -13,7 +13,7 @@ namespace JudoPayDotNet.Clients
 {
     internal class BaseRegisterCards : JudoPayClient
     {
-        protected readonly IValidator<RegisterCardModel> RegisterCardValidator = new RegisterCardValidator();
+        protected readonly IValidator<CardPaymentModel> RegisterCardValidator = new CardPaymentValidator();
         private readonly string _createAddress;
 
 
@@ -23,11 +23,11 @@ namespace JudoPayDotNet.Clients
             _createAddress = createAddress;
         }
 
-        public Task<IResult<ITransactionResult>> Create(RegisterCardModel registerCard)
+        public Task<IResult<ITransactionResult>> Create(CardPaymentModel registerCard)
         {
-            var validationError = Validate<RegisterCardModel, ITransactionResult>(RegisterCardValidator, registerCard);
+            var validationError = Validate<CardPaymentModel, ITransactionResult>(RegisterCardValidator, registerCard);
 
-            return validationError ?? PostInternal<RegisterCardModel, ITransactionResult>(_createAddress, registerCard);
+            return validationError ?? PostInternal<CardPaymentModel, ITransactionResult>(_createAddress, registerCard);
         }
     }
 }

--- a/JudoPayDotNet/Clients/IRegisterCards.cs
+++ b/JudoPayDotNet/Clients/IRegisterCards.cs
@@ -21,6 +21,6 @@ namespace JudoPayDotNet.Clients
         /// </summary>
         /// <param name="registerCard">The card to register.</param>
         /// <returns>The result of the registration of the card</returns>
-        Task<IResult<ITransactionResult>> Create(RegisterCardModel registerCard);
+        Task<IResult<ITransactionResult>> Create(CardPaymentModel registerCard);
     }
 }

--- a/JudoPayDotNet/Models/ThreeDResultModel.cs
+++ b/JudoPayDotNet/Models/ThreeDResultModel.cs
@@ -16,5 +16,9 @@ namespace JudoPayDotNet.Models
         /// </value>
         [DataMember]
         public string PaRes { get; set; }
+
+        [DataMember]
+        public string Md { get; set; }
+        
     }
 }

--- a/JudoPayDotNetIntegrationTests/RegisterCardTests.cs
+++ b/JudoPayDotNetIntegrationTests/RegisterCardTests.cs
@@ -16,7 +16,7 @@ namespace JudoPayDotNetIntegrationTests
                 Configuration.Secret, 
                 Configuration.Baseaddress);
 
-            var registerCardModel = new RegisterCardModel
+            var registerCardModel = new CardPaymentModel
             {
                 YourConsumerReference = Guid.NewGuid().ToString(),
                 CardNumber = "4976000000003436",
@@ -47,7 +47,7 @@ namespace JudoPayDotNetIntegrationTests
 
             var consumerReference = Guid.NewGuid().ToString();
 
-            var registerCard = new RegisterCardModel
+            var registerCard = new CardPaymentModel
             {
                 YourConsumerReference = consumerReference,
                 CardNumber = "4976000000003436",
@@ -114,7 +114,7 @@ namespace JudoPayDotNetIntegrationTests
                 Configuration.Secret,
                 Configuration.Baseaddress);
 
-            var registerCard = new RegisterCardModel
+            var registerCard = new CardPaymentModel
             {
                 YourConsumerReference = "432438862",
                 CardNumber = "4221690000004963",

--- a/JudoPayDotNetTests/Clients/RegisterCardsTests.cs
+++ b/JudoPayDotNetTests/Clients/RegisterCardsTests.cs
@@ -30,6 +30,7 @@ namespace JudoPayDotNetTests.Clients
                 {
                     yield return new TestCaseData(new CardPaymentModel
                     {
+                        Amount = 2.0m,
                         CardAddress = new CardAddressModel
                         {
                             Line1 = "Test Street",
@@ -39,6 +40,10 @@ namespace JudoPayDotNetTests.Clients
                         CardNumber = "348417606737499",
                         ExpiryDate = "120615",
                         YourConsumerReference = "User10",
+                        CV2 = "420",
+                        JudoId = "14562",
+                        MobileNumber = "07745352515",
+                        YourPaymentReference = "Pay1234"
                     },
                         @"{
                         receiptId : '134567',
@@ -69,8 +74,9 @@ namespace JudoPayDotNetTests.Clients
             {
                 get
                 {
-                    yield return new TestCaseData(new RegisterCardModel
+                    yield return new TestCaseData(new CardPaymentModel
                     {
+                        Amount = 2.0m,
                         CardAddress = new CardAddressModel
                         {
                             Line1 = "Test Street",
@@ -80,6 +86,9 @@ namespace JudoPayDotNetTests.Clients
                         CardNumber = "348417606737499",
                         ExpiryDate = "120615",
                         YourConsumerReference = "User10",
+                        CV2 = "420",
+                        JudoId = "14562",
+                        MobileNumber = "07745352515",
                     },
                         @"    
                     {

--- a/JudoPayDotNetTests/Clients/RegisterCardsTests.cs
+++ b/JudoPayDotNetTests/Clients/RegisterCardsTests.cs
@@ -28,7 +28,7 @@ namespace JudoPayDotNetTests.Clients
             {
                 get
                 {
-                    yield return new TestCaseData(new RegisterCardModel
+                    yield return new TestCaseData(new CardPaymentModel
                     {
                         CardAddress = new CardAddressModel
                         {
@@ -152,7 +152,7 @@ namespace JudoPayDotNetTests.Clients
 
 
         [Test, TestCaseSource(typeof(global::JudoPayDotNetTests.Clients.RegisterCardsTests.RegisterCardsTestSource), "SuccessTestCases")]
-        public void RegisterCardWithSuccess(RegisterCardModel registerCard, string responseData, string receiptId)
+        public void RegisterCardWithSuccess(CardPaymentModel registerCard, string responseData, string receiptId)
         {
             var httpClient = Substitute.For<IHttpClient>();
             var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(responseData) };
@@ -181,7 +181,7 @@ namespace JudoPayDotNetTests.Clients
         }
 
         [Test, TestCaseSource(typeof(global::JudoPayDotNetTests.Clients.RegisterCardsTests.RegisterCardsTestSource), "FailureTestCases")]
-        public void RegisterCardWithError(RegisterCardModel registerCard, string responseData, JudoApiError errorType)
+        public void RegisterCardWithError(CardPaymentModel registerCard, string responseData, JudoApiError errorType)
         {
             var httpClient = Substitute.For<IHttpClient>();
             var response = new HttpResponseMessage(HttpStatusCode.BadRequest)

--- a/JudoPayDotNetTests/Clients/RegisterCardsTests.cs
+++ b/JudoPayDotNetTests/Clients/RegisterCardsTests.cs
@@ -86,7 +86,6 @@ namespace JudoPayDotNetTests.Clients
                         CardNumber = "348417606737499",
                         ExpiryDate = "120615",
                         YourConsumerReference = "User10",
-                        CV2 = "420",
                         JudoId = "14562",
                         MobileNumber = "07745352515",
                     },
@@ -98,9 +97,9 @@ namespace JudoPayDotNetTests.Clients
                                         errorMessage : 'To large',
                                         detailErrorMessage : 'This field has to be at most 20 characters'
                                         }],
-                        errorType : '200'
+                        errorType : '1'
                     }",
-                        200).SetName("RegisterCardWithoutSuccess");
+                        1).SetName("RegisterCardWithoutSuccess");
                 }
             }
 
@@ -152,9 +151,9 @@ namespace JudoPayDotNetTests.Clients
                                         errorMessage : 'To large',
                                         detailErrorMessage : 'This field has to be at most 20 characters'
                                         }],
-                        errorType : '200'
+                        errorType : '1'
                     }",
-                            200).SetName("ValidateWithoutSuccess");
+                            1).SetName("ValidateWithoutSuccess");
                 }
             }
         }


### PR DESCRIPTION
switched register card over to use the CardPaymentModel so JudoID mandetory, added MD to the threeDResultModel, it wasn't being passed through before