### PR TITLE
Http headers on collection and refund

### DIFF
--- a/JudoPayDotNet/Clients/JudoPayClient.cs
+++ b/JudoPayDotNet/Clients/JudoPayClient.cs
@@ -20,7 +20,7 @@ namespace JudoPayDotNet.Clients
     {
         private readonly IClient _client;
         private readonly ILog _logger;
-        internal const String SDK_VERSION = "1.3.0";
+        internal const String SDK_VERSION = "1.3.1";
         private readonly Dictionary<string, IResponse> _uniqueResponses;
         public bool _deDuplicateTransactions = false;
 
@@ -80,11 +80,9 @@ namespace JudoPayDotNet.Clients
         /// <param name="address">The URI.</param>
         /// <param name="entity">The body entity.</param>
         /// <param name="parameters">The query string parameters.</param>
-        /// /// <param name="extraHeaders">Any extra http headers to send with the request</param>
         /// <returns>A result object that wraps the parsed response and an error if something not right happened</returns>
         protected async Task<IResult<R>> PostInternal<T, R>(string address, T entity,
-        Dictionary<string, string> parameters = null,
-        Dictionary<string, string> extraHeaders = null)
+        Dictionary<string, string> parameters = null)
         where T : class
         where R : class
         {
@@ -109,6 +107,13 @@ namespace JudoPayDotNet.Clients
                     }
 
                 }
+            }
+
+            Dictionary<string, string> extraHeaders = null;
+            IModelWithHttpHeaders headersModel = entity as IModelWithHttpHeaders;
+            if (headersModel != null && headersModel.HttpHeaders.Count > 0)
+            {
+                extraHeaders = headersModel.HttpHeaders;
             }
 
             var response = await _client.Post<R>(address, parameters, extraHeaders, entity).ConfigureAwait(false);
@@ -152,15 +157,21 @@ namespace JudoPayDotNet.Clients
         /// <param name="address">The URI.</param>
         /// <param name="entity">The body entity.</param>
         /// <param name="parameters">The query string parameters.</param>
-        /// /// <param name="extraHeaders">Any extra http headers to send with the request</param>
         /// <returns>A result object that wraps the parsed response and an error if something not right happened</returns>
         protected async Task<IResult<R>> PutInternal<T, R>(string address,
         T entity,
-        Dictionary<string, string> parameters = null,
-        Dictionary<string, string> extraHeaders = null)
+        Dictionary<string, string> parameters = null)
         where T : class
         where R : class
         {
+
+            Dictionary<string, string> extraHeaders = null;
+            IModelWithHttpHeaders headersModel = entity as IModelWithHttpHeaders;
+            if (headersModel != null && headersModel.HttpHeaders.Count > 0)
+            {
+                extraHeaders = headersModel.HttpHeaders;
+            }
+
             R result = null;
 
             var response = await _client.Update<R>(address, parameters, extraHeaders, entity).ConfigureAwait(false);

--- a/JudoPayDotNet/JudoPayDotNet.csproj
+++ b/JudoPayDotNet/JudoPayDotNet.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Http\AuthType.cs" />
     <Compile Include="Models\CustomDeserializers\TransactionTypeConvertor.cs" />
     <Compile Include="Models\EncryptedPaymentMessage.cs" />
+    <Compile Include="Models\IModelWithHttpHeaders.cs" />
     <Compile Include="Models\JudoApiError.cs" />
     <Compile Include="Errors\BadResponseError.cs" />
     <Compile Include="Errors\ConnectionError.cs" />
@@ -157,6 +158,7 @@
     <Compile Include="Models\PKPaymentInnerModel.cs" />
     <Compile Include="Models\PKPaymentModel.cs" />
     <Compile Include="Models\PKPaymentTokenModel.cs" />
+    <Compile Include="Models\ReferencingTransactionBase.cs" />
     <Compile Include="Models\RefundModel.cs" />
     <Compile Include="Models\RegisterCardModel.cs" />
     <Compile Include="Models\Result.cs" />

--- a/JudoPayDotNet/Models/CollectionModel.cs
+++ b/JudoPayDotNet/Models/CollectionModel.cs
@@ -9,7 +9,7 @@ namespace JudoPayDotNet.Models
     /// </summary>
     // ReSharper disable UnusedMember.Global
     [DataContract]
-    public class CollectionModel
+    public class CollectionModel : ReferencingTransactionBase
     {
 
         public CollectionModel()

--- a/JudoPayDotNet/Models/IModelWithHttpHeaders.cs
+++ b/JudoPayDotNet/Models/IModelWithHttpHeaders.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace JudoPayDotNet.Models
+{
+    public interface IModelWithHttpHeaders
+    {
+        /// <summary>
+        /// Optional extra http headers to include in the request
+        /// </summary>
+        Dictionary<string, string> HttpHeaders { get; }
+    }
+}

--- a/JudoPayDotNet/Models/PKPaymentModel.cs
+++ b/JudoPayDotNet/Models/PKPaymentModel.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Runtime.Serialization;
+
+// ReSharper disable ClassNeverInstantiated.Global
 
 namespace JudoPayDotNet.Models
 {

--- a/JudoPayDotNet/Models/PaymentModel.cs
+++ b/JudoPayDotNet/Models/PaymentModel.cs
@@ -11,7 +11,7 @@ namespace JudoPayDotNet.Models
     /// </summary>
     // ReSharper disable UnusedMember.Global
     [DataContract]
-    public abstract class PaymentModel
+    public abstract class PaymentModel : IModelWithHttpHeaders
     {
         protected PaymentModel()
         {
@@ -169,10 +169,16 @@ namespace JudoPayDotNet.Models
         public string AcceptHeaders { get; set; }
         // ReSharper restore UnusedAutoPropertyAccessor.Global
 
+        private Dictionary<string, string> _httpHeaders;
+
         /// <summary>
-        /// Optional extra http headers to include in the request
+        /// Allows you to set HTTP headers on requests
         /// </summary>
-        public Dictionary<string,string> HttpHeaders { get; set; }
+        [IgnoreDataMember]
+        public Dictionary<string, string> HttpHeaders
+        {
+            get { return _httpHeaders ?? (_httpHeaders = new Dictionary<string, string>()); }
+        }
 
         public void ProvisionSDKVersion()
         {

--- a/JudoPayDotNet/Models/ReferencingTransactionBase.cs
+++ b/JudoPayDotNet/Models/ReferencingTransactionBase.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace JudoPayDotNet.Models
+{
+    /// <summary>
+    /// The base class for transactions that reference other transactions (like voids, collections and refunds)
+    /// </summary>
+    public abstract class ReferencingTransactionBase :  IModelWithHttpHeaders
+    {
+        private Dictionary<string, string> _httpHeaders;
+
+        /// <summary>
+        /// Allows you to set HTTP headers on requests
+        /// </summary>
+        public Dictionary<string, string> HttpHeaders
+        {
+            get { return _httpHeaders ?? (_httpHeaders = new Dictionary<string, string>()); }
+        }
+    }
+}

--- a/JudoPayDotNet/Models/RefundModel.cs
+++ b/JudoPayDotNet/Models/RefundModel.cs
@@ -9,7 +9,7 @@ namespace JudoPayDotNet.Models
     /// <remarks>You can refund all or part of a collection or payment</remarks>
     // ReSharper disable UnusedMember.Global
     [DataContract]
-    public class RefundModel
+    public class RefundModel : ReferencingTransactionBase
     {
         public RefundModel()
         {

--- a/JudoPayDotNet/Models/WebPaymentRequestModel.cs
+++ b/JudoPayDotNet/Models/WebPaymentRequestModel.cs
@@ -14,7 +14,7 @@ namespace JudoPayDotNet.Models
     // ReSharper disable UnusedMember.Global
     // ReSharper disable UnusedAutoPropertyAccessor.Global
     [DataContract]
-    public class WebPaymentRequestModel
+    public class WebPaymentRequestModel : IModelWithHttpHeaders
     {
 
         public WebPaymentRequestModel()
@@ -189,6 +189,18 @@ namespace JudoPayDotNet.Models
 
         [DataMember(EmitDefaultValue = false)]
         public WebPaymentOperation? WebPaymentOperation { get; set; }
+
+
+        private Dictionary<string, string> _httpHeaders;
+
+        /// <summary>
+        /// Allows you to set HTTP headers on requests
+        /// </summary>
+        [IgnoreDataMember]
+        public Dictionary<string, string> HttpHeaders
+        {
+            get { return _httpHeaders ?? (_httpHeaders = new Dictionary<string, string>()); }
+        }
     }
     // ReSharper restore UnusedAutoPropertyAccessor.Global
     // ReSharper restore UnusedMember.Global

--- a/JudoPayDotNetTests/Clients/PreAuthTests.cs
+++ b/JudoPayDotNetTests/Clients/PreAuthTests.cs
@@ -295,6 +295,47 @@ namespace JudoPayDotNetTests.Clients
             Assert.That(paymentReceiptResult.Response.ReceiptId, Is.EqualTo(134567));
         }
 
+        [Test, TestCaseSource(typeof(PreAuthTestSource), "SuccessTestCases")]
+        public void ExtraHeadersAreSent(PaymentModel payment, string responseData, string receiptId)
+        {
+            const string EXTRA_HEADER_NAME = "X-Extra-Request-Header";
+
+            var httpClient = Substitute.For<IHttpClient>();
+            var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(responseData) };
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            var responseTask = new TaskCompletionSource<HttpResponseMessage>();
+            responseTask.SetResult(response);
+
+            httpClient.SendAsync(Arg.Is<HttpRequestMessage>(r => r.Headers.Contains(EXTRA_HEADER_NAME)))
+                .Returns(responseTask.Task);
+
+            var client = new Client(new Connection(httpClient,
+                                                    DotNetLoggerFactory.Create,
+                                                    "http://something.com"));
+
+            var judo = new JudoPayApi(DotNetLoggerFactory.Create, client);
+
+            IResult<ITransactionResult> paymentReceiptResult = null;
+
+            payment.HttpHeaders.Add(EXTRA_HEADER_NAME, "some random value");
+
+            // ReSharper disable CanBeReplacedWithTryCastAndCheckForNull
+            if (payment is CardPaymentModel)
+            {
+                paymentReceiptResult = judo.Payments.Create((CardPaymentModel)payment).Result;
+            }
+            else if (payment is TokenPaymentModel)
+            {
+                paymentReceiptResult = judo.Payments.Create((TokenPaymentModel)payment).Result;
+            }
+            // ReSharper restore CanBeReplacedWithTryCastAndCheckForNull
+
+            Assert.NotNull(paymentReceiptResult);
+            Assert.IsFalse(paymentReceiptResult.HasError);
+            Assert.NotNull(paymentReceiptResult.Response);
+            Assert.That(paymentReceiptResult.Response.ReceiptId, Is.EqualTo(134567));
+        }
+
         [Test, TestCaseSource(typeof(PreAuthTestSource), "FailureTestCases")]
         public void PreAuthWithError(PaymentModel payment, string responseData, JudoApiError errorType)
         {

--- a/JudoPayDotNetTests/Clients/WebPayments/PaymentsTests.cs
+++ b/JudoPayDotNetTests/Clients/WebPayments/PaymentsTests.cs
@@ -68,6 +68,11 @@ namespace JudoPayDotNetTests.Clients.WebPayments
                     }
                 }
             };
+
+            const string EXTRA_HEADER_NAME = "ExtraHeader";
+
+            request.HttpHeaders.Add(EXTRA_HEADER_NAME, "ExtraHeaderValue");
+
             var response = new HttpResponseMessage(HttpStatusCode.OK) {Content = new StringContent(@"{
 		                                             postUrl : 'http://test.com',
 		                                             reference : '1342423'   
@@ -76,7 +81,8 @@ namespace JudoPayDotNetTests.Clients.WebPayments
             var responseTask = new TaskCompletionSource<HttpResponseMessage>();
             responseTask.SetResult(response);
 
-            httpClient.SendAsync(Arg.Any<HttpRequestMessage>()).Returns(responseTask.Task);
+            httpClient.SendAsync(Arg.Is<HttpRequestMessage>(r => r.Headers.Contains(EXTRA_HEADER_NAME)))
+                .Returns(responseTask.Task);
 
             var client = new Client(new Connection(httpClient,
                                                     DotNetLoggerFactory.Create,
@@ -146,6 +152,11 @@ namespace JudoPayDotNetTests.Clients.WebPayments
                     }
                 }
             };
+
+            const string EXTRA_HEADER_NAME = "ExtraHeader";
+
+            request.HttpHeaders.Add(EXTRA_HEADER_NAME, "ExtraHeaderValue");
+
             var response = new HttpResponseMessage(HttpStatusCode.OK) {Content = new StringContent(@"{
     	                                            amount : 10,
     	                                            cardAddress : 
@@ -205,7 +216,8 @@ namespace JudoPayDotNetTests.Clients.WebPayments
             var responseTask = new TaskCompletionSource<HttpResponseMessage>();
             responseTask.SetResult(response);
 
-            httpClient.SendAsync(Arg.Any<HttpRequestMessage>()).Returns(responseTask.Task);
+            httpClient.SendAsync(Arg.Is<HttpRequestMessage>(r => r.Headers.Contains(EXTRA_HEADER_NAME)))
+                .Returns(responseTask.Task);
 
             var client = new Client(new Connection(httpClient,
                                                     DotNetLoggerFactory.Create,

--- a/JudoPayDotNetTests/Clients/WebPayments/TransactionsTests.cs
+++ b/JudoPayDotNetTests/Clients/WebPayments/TransactionsTests.cs
@@ -80,9 +80,9 @@ namespace JudoPayDotNetTests.Clients.WebPayments
 
             var judo = new JudoPayApi(DotNetLoggerFactory.Create, client);
 
-            const string receiptId = "1245";
+            const string RECEIPT_ID = "1245";
 
-            var paymentReceiptResult = judo.WebPayments.Transactions.GetByReceipt(receiptId).Result;
+            var paymentReceiptResult = judo.WebPayments.Transactions.GetByReceipt(RECEIPT_ID).Result;
 
             Assert.NotNull(paymentReceiptResult);
             Assert.IsFalse(paymentReceiptResult.HasError);
@@ -157,14 +157,14 @@ namespace JudoPayDotNetTests.Clients.WebPayments
 
             var judo = new JudoPayApi(DotNetLoggerFactory.Create, client);
 
-            const string reference = "42421";
+            const string REFERENCE = "42421";
 
-            var paymentReceiptResult = judo.WebPayments.Transactions.Get(reference).Result;
+            var paymentReceiptResult = judo.WebPayments.Transactions.Get(REFERENCE).Result;
 
             Assert.NotNull(paymentReceiptResult);
             Assert.IsFalse(paymentReceiptResult.HasError);
             Assert.NotNull(paymentReceiptResult.Response);
-            Assert.That(paymentReceiptResult.Response.Reference, Is.EqualTo(reference));
+            Assert.That(paymentReceiptResult.Response.Reference, Is.EqualTo(REFERENCE));
             Assert.That(paymentReceiptResult.Response.Status, Is.EqualTo(WebPaymentStatus.Open));
             Assert.That(paymentReceiptResult.Response.Receipt.ReceiptId, Is.EqualTo(134567));
         }

--- a/JudoPayDotNetTests/Headers/HeaderChainAdded.cs
+++ b/JudoPayDotNetTests/Headers/HeaderChainAdded.cs
@@ -16,16 +16,16 @@ namespace JudoPayDotNetTests.Headers
         [Test]
         public void VerifyTheExistanceOfAuthenticationAndVersioning()
         {
-            const string versionHeader = "api-version-header";
-            const string versionHeaderValue = "3.2";
+            const string VERSION_HEADER = "api-version-header";
+            const string VERSION_HEADER_VALUE = "3.2";
 
             var testHandler = new TestHandler((request, cancelation) =>
             {
-                var requestVersionHeader = request.Headers.FirstOrDefault(h => h.Key == versionHeader);
+                var requestVersionHeader = request.Headers.FirstOrDefault(h => h.Key == VERSION_HEADER);
 
                 Assert.IsNotNull(requestVersionHeader);
                 Assert.That(requestVersionHeader.Value.FirstOrDefault(), Is.Not.Null.Or.Empty);
-                Assert.AreEqual(versionHeaderValue, requestVersionHeader.Value.FirstOrDefault());
+                Assert.AreEqual(VERSION_HEADER_VALUE, requestVersionHeader.Value.FirstOrDefault());
 
                 Assert.AreEqual("Bearer",
                     request.Headers.Authorization.Scheme);
@@ -36,14 +36,14 @@ namespace JudoPayDotNetTests.Headers
             var logger = Substitute.For<ILog>();
             var credentials = new Credentials("ABC");
 
-            var versionHandler = new VersioningHandler(versionHeader, versionHeaderValue);
+            var versionHandler = new VersioningHandler(VERSION_HEADER, VERSION_HEADER_VALUE);
             var authorizationHandlerhandler = new AuthorizationHandler(credentials, logger);
 
             var clientWrapper = new HttpClientWrapper(versionHandler, authorizationHandlerhandler, testHandler);
 
             var client = clientWrapper.HttpClient;
 
-// ReSharper disable once MethodSupportsCancellation
+            // ReSharper disable once MethodSupportsCancellation
             var response = client.GetAsync("http://lodididki");
 
             Assert.AreEqual(HttpStatusCode.OK, response.Result.StatusCode);

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Judo .NET SDK
 
-[![Build status](https://ci.appveyor.com/api/projects/status/y9mrqtjr0cf1g5li?svg=true)](https://ci.appveyor.com/project/JudoPayments/dotnetsdk) <a href="https://scan.coverity.com/projects/judopaydotnetsdk">
+<a href="https://scan.coverity.com/projects/judopaydotnetsdk">
   <img alt="Coverity Scan Build Status"
        src="https://img.shields.io/coverity/scan/6752.svg"/>
 </a>


### PR DESCRIPTION
I've added http headers to the collection and refund models, and improved the way I implemented the mapping of headers onto the actual request. Also included HTTP headers in the unit tests