### PR TITLE
Allow Xamarin to pass user agent params to .NET SDK

### DIFF
--- a/JudoPayDotNet/Http/HttpClientWrapper.cs
+++ b/JudoPayDotNet/Http/HttpClientWrapper.cs
@@ -21,7 +21,7 @@ namespace JudoPayDotNet.Http
 
         public HttpClientWrapper()
         {
-            HttpClient = CreateHttpClient((IEnumerable<ProductInfoHeaderValue>)null);
+            HttpClient = CreateHttpClient(null);
         }
 
         public HttpClientWrapper(DelegatingHandler handler)

--- a/JudoPayDotNetTests/Headers/HeaderChainAdded.cs
+++ b/JudoPayDotNetTests/Headers/HeaderChainAdded.cs
@@ -118,7 +118,7 @@ namespace JudoPayDotNetTests.Headers
                                   {
                                       // Ensure User-Agent is sent
                                       Assert.That(request.Headers.UserAgent, Is.Not.Null.Or.Empty);
-                                      Assert.That(request.Headers.UserAgent.Count, Is.EqualTo(2));
+                                      Assert.That(request.Headers.UserAgent.Count, Is.EqualTo(4));
 
                                       Assert.That(request.Headers.UserAgent, Has.Exactly(1).Matches<ProductInfoHeaderValue>(a => a.Product.Name == "TEST"));
 

--- a/JudoPayDotNetTests/Headers/HeaderChainAdded.cs
+++ b/JudoPayDotNetTests/Headers/HeaderChainAdded.cs
@@ -120,7 +120,7 @@ namespace JudoPayDotNetTests.Headers
                                       Assert.That(request.Headers.UserAgent, Is.Not.Null.Or.Empty);
                                       Assert.That(request.Headers.UserAgent.Count, Is.EqualTo(4));
 
-                                      Assert.That(request.Headers.UserAgent, Has.Exactly(1).Matches<ProductInfoHeaderValue>(a => a.Product.Name == "TEST"));
+                                      Assert.That(request.Headers.UserAgent.Any(a => a.Product.Name == "TEST"));
 
                                       return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
                                   });


### PR DESCRIPTION
Allow Xamarin to pass additional useragent values when constructing the ```HttpClientWrapper```
