### PR TITLE
Adding device identifier to the judopay response

### DIFF
--- a/JudoPayDotNet/Http/VersioningHandler.cs
+++ b/JudoPayDotNet/Http/VersioningHandler.cs
@@ -13,7 +13,7 @@ namespace JudoPayDotNet.Http
     {
         public const string API_VERSION_HEADER = "api-version";
 
-        internal const string DEFAULT_API_VERSION = "5.3.0.0";
+        internal const string DEFAULT_API_VERSION = "5.4.0.0";
 
         private readonly string _apiVersionValue;
 

--- a/JudoPayDotNet/JudoPayDotNet.csproj
+++ b/JudoPayDotNet/JudoPayDotNet.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Errors\ModelError.cs" />
     <Compile Include="Http\AuthType.cs" />
     <Compile Include="Models\CustomDeserializers\TransactionTypeConvertor.cs" />
+    <Compile Include="Models\Device.cs" />
     <Compile Include="Models\EncryptedPaymentMessage.cs" />
     <Compile Include="Models\IModelWithHttpHeaders.cs" />
     <Compile Include="Models\JudoApiError.cs" />

--- a/JudoPayDotNet/Models/Device.cs
+++ b/JudoPayDotNet/Models/Device.cs
@@ -10,13 +10,13 @@ namespace JudoPayDotNet.Models
     public class Device
     {
         /// <summary>
-        /// Gets or sets the consumer token.
+        /// Gets or sets the device identity.
         /// </summary>
         /// <value>
-        /// The consumer token.
+        /// The devices identity.
         /// </value>
         [DataMember(EmitDefaultValue = false)]
-        public string Identity { get; set; }
+        public string Identifier { get; set; }
 
         // ReSharper restore UnusedAutoPropertyAccessor.Global
     }

--- a/JudoPayDotNet/Models/Device.cs
+++ b/JudoPayDotNet/Models/Device.cs
@@ -1,0 +1,23 @@
+﻿using System.Runtime.Serialization;
+
+namespace JudoPayDotNet.Models
+{
+    /// <summary>
+    /// Details of the device being used in the requested operation (add card/payment)
+    /// </summary>
+    // ReSharper disable UnusedAutoPropertyAccessor.Global
+    [DataContract(Name = "Device", Namespace = "")]
+    public class Device
+    {
+        /// <summary>
+        /// Gets or sets the consumer token.
+        /// </summary>
+        /// <value>
+        /// The consumer token.
+        /// </value>
+        [DataMember(EmitDefaultValue = false)]
+        public string Identity { get; set; }
+
+        // ReSharper restore UnusedAutoPropertyAccessor.Global
+    }
+}

--- a/JudoPayDotNet/Models/PaymentReceiptModel.cs
+++ b/JudoPayDotNet/Models/PaymentReceiptModel.cs
@@ -190,6 +190,15 @@ namespace JudoPayDotNet.Models
         public Consumer Consumer { get; set; }
 
         /// <summary>
+        /// Gets or sets the consumer.
+        /// </summary>
+        /// <value>
+        /// The consumer.
+        /// </value>
+        [DataMember]
+        public Device Device { get; set; }
+
+        /// <summary>
         /// Gets or sets the risk score.
         /// </summary>
         /// <value>

--- a/JudoPayDotNetIntegrationTests/IntegrationTestsBase.cs
+++ b/JudoPayDotNetIntegrationTests/IntegrationTestsBase.cs
@@ -41,7 +41,7 @@ namespace JudoPayDotNetIntegrationTests
             };
         }
 
-        protected TokenPaymentModel GeTokenPaymentModel(string cardToken, string yourConsumerReference = null, decimal amount = 25)
+        protected TokenPaymentModel GetTokenPaymentModel(string cardToken, string yourConsumerReference = null, decimal amount = 25)
         {
             if (string.IsNullOrEmpty(yourConsumerReference))
                 yourConsumerReference = Guid.NewGuid().ToString();

--- a/JudoPayDotNetIntegrationTests/PaymentTest.cs
+++ b/JudoPayDotNetIntegrationTests/PaymentTest.cs
@@ -41,11 +41,11 @@ namespace JudoPayDotNetIntegrationTests
             // Fetch the card token
             var cardToken = receipt.CardDetails.CardToken;
 
-            var paymentWithToken = GeTokenPaymentModel(cardToken, consumerReference, 26);
+            var paymentWithToken = GetTokenPaymentModel(cardToken, consumerReference, 26);
 
             response = JudoPayApi.Payments.Create(paymentWithToken).Result;
 
-            paymentWithToken = GeTokenPaymentModel(cardToken, consumerReference, 27);
+            paymentWithToken = GetTokenPaymentModel(cardToken, consumerReference, 27);
 
             response = JudoPayApi.Payments.Create(paymentWithToken).Result;
 

--- a/JudoPayDotNetIntegrationTests/RegisterCardTests.cs
+++ b/JudoPayDotNetIntegrationTests/RegisterCardTests.cs
@@ -42,11 +42,11 @@ namespace JudoPayDotNetIntegrationTests
             // Fetch the card token
             var cardToken = receipt.CardDetails.CardToken;
 
-            var paymentWithToken = GeTokenPaymentModel(cardToken, consumerReference, 26);
+            var paymentWithToken = GetTokenPaymentModel(cardToken, consumerReference, 26);
 
             response = JudoPayApi.Payments.Create(paymentWithToken).Result;
 
-            paymentWithToken = GeTokenPaymentModel(cardToken, consumerReference, 27);
+            paymentWithToken = GetTokenPaymentModel(cardToken, consumerReference, 27);
 
             response = JudoPayApi.Payments.Create(paymentWithToken).Result;
 

--- a/JudoPayDotNetIntegrationTests/app.config
+++ b/JudoPayDotNetIntegrationTests/app.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="ApiVersion" value="5.3.0.0" />
+    <add key="ApiVersion" value="5.4.0.0" />
     <add key="SandboxUrl" value="https://gw1.judopay-sandbox.com/" />
     <add key="LiveUrl" value="https://gw1.judopay.com/" />
     <add key="WebpaymentsUrl" value="https://pay.judopay-sandbox.com/v1/Pay" />


### PR DESCRIPTION
Judo has upped the version to 5.4 as the receipt model now contains the device identifier.