### PR TITLE
Enabling transactions with 0 amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Changes on 2018-03-01
+- Removed cliend side validation for transactions with 0 amount
+
+## Changes on 2018-02-28
+- Added one time token payment
+
 ## Changes on 2017-04-04
 
 #### Updated

--- a/JudoPayDotNet/Models/Validations/PaymentsBaseValidator.cs
+++ b/JudoPayDotNet/Models/Validations/PaymentsBaseValidator.cs
@@ -17,7 +17,7 @@ namespace JudoPayDotNet.Models.Validations
                  .NotEmpty()
                  .WithErrorCode(((int)JudoModelErrorCode.Amount_Not_Valid).ToString())
                  .WithMessage("You must supply the amount you wish to pay.")
-                 .GreaterThanOrEqualTo(0.01M)
+                 .GreaterThanOrEqualTo(0.0M)
                  .WithErrorCode(((int)JudoModelErrorCode.Amount_Greater_Than_0).ToString())
                  .WithMessage("Sorry, this payment amount is not valid.");
 

--- a/JudoPayDotNetIntegrationTests/WebPaymentsTests.cs
+++ b/JudoPayDotNetIntegrationTests/WebPaymentsTests.cs
@@ -149,7 +149,7 @@ namespace JudoPayDotNetIntegrationTests
             // Forms - Post a form with credentials and cookie and form following variables:
             // url= /v1/Pay variables: CardNumber, ExpiryDate, Cv2, form variable: __RequestVerificationToken
 
-            var formField = doc.DocumentNode.SelectSingleNode("//input[@name='__RequestVerificationToken']");
+           var formField = doc.DocumentNode.SelectSingleNode("//input[@name='__RequestVerificationToken']");
 
             var requestVerificationToken = formField.GetAttributeValue("value", "");
 
@@ -165,7 +165,8 @@ namespace JudoPayDotNetIntegrationTests
                 new KeyValuePair<string, string>("CardAddress.CountryCode", "826"), 
                 new KeyValuePair<string, string>("CardAddress.PostCode", "TR14 8PA"), 
                 new KeyValuePair<string, string>("ExpiryDate", "12/20"), 
-                new KeyValuePair<string, string>("Reference", reference)
+                new KeyValuePair<string, string>("Reference", reference),
+                new KeyValuePair<string, string>("YourConsumerReference", "4235325"), 
             });
 
             formRequest = CreateJudoApiRequest(Configuration.WebpaymentsUrl, HttpMethod.Post, "5.3.0.0", Configuration.ElevatedPrivilegesToken,


### PR DESCRIPTION
Removed client validation of 0 amount transactions. Server side the validation is done depending on business factors.