### PR TITLE
Updating badge & appveyor

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,5 @@
 # Judo .NET SDK
-
-[![Build status](https://ci.appveyor.com/api/projects/status/63dbbef4dxrual5f?svg=true)](https://ci.appveyor.com/project/JudoPayments/dotnetsdk)
+[![Build status](https://ci.appveyor.com/api/projects/status/63dbbef4dxrual5f/branch/master?svg=true)](https://ci.appveyor.com/project/JudoPayments/dotnetsdk/branch/master)
 
 The .NET SDK is a client for our Judopay API, which provides card payment processing for mobile apps and websites.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 version: 2.0.{build}
 image: Visual Studio 2017
+skip_branch_with_pr: true
 configuration: Release
 dotnet_csproj:
   patch: true


### PR DESCRIPTION
The badge was pointing at the latest build so was displaying red when master was actually green.

Stopping double builds on PRs