### PR TITLE
Adding check card

### DIFF
--- a/JudoPayDotNet/Clients/CheckCards.cs
+++ b/JudoPayDotNet/Clients/CheckCards.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading.Tasks;
+using FluentValidation;
+using JudoPayDotNet.Http;
+using JudoPayDotNet.Logging;
+using JudoPayDotNet.Models;
+using JudoPayDotNet.Models.Validations;
+
+namespace JudoPayDotNet.Clients
+{
+    internal class CheckCards : JudoPayClient, ICheckCard
+    {
+        private readonly IValidator<CheckCardModel> _validator = new CheckCardValidator();
+
+        private const string CheckCardAddress = "transactions/checkcard";
+
+        public CheckCards(ILog logger, IClient client, bool deDuplicate = false)
+            : base(logger, client)
+        {
+            _deDuplicateTransactions = deDuplicate;
+        }
+
+        public Task<IResult<ITransactionResult>> Create(CheckCardModel checkCardModel)
+        {
+            var validationError = Validate<CheckCardModel, ITransactionResult>(_validator, checkCardModel);
+            return validationError ?? PostInternal<CheckCardModel, ITransactionResult>(CheckCardAddress, checkCardModel);
+        }
+    }
+}

--- a/JudoPayDotNet/Clients/ICheckCard.cs
+++ b/JudoPayDotNet/Clients/ICheckCard.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using JudoPayDotNet.Models;
+
+namespace JudoPayDotNet.Clients
+{
+    /// <summary>
+    /// The entity responsible for processing and validating cards
+    /// </summary>
+    /// <remarks>
+    /// This entity allows you to check the card of the consumer
+    /// </remarks>
+    public interface ICheckCard
+    {
+        /// <summary>
+        /// Performs a card check against the card. This doesnt do an authorisation, it just checks whether or not the card is valid
+        /// </summary>
+        /// <param name="checkCardModel">The card to check.</param>
+        /// <returns>The result of the card check</returns>
+        Task<IResult<ITransactionResult>> Create(CheckCardModel checkCardModel);
+    }
+}

--- a/JudoPayDotNet/JudoPayApi.cs
+++ b/JudoPayDotNet/JudoPayApi.cs
@@ -32,6 +32,7 @@ namespace JudoPayDotNet
         public ISaveCard SaveCards { get; set; }
         public IVoids Voids { get; set; }
         public Connection Connection { get; }
+        public ICheckCard CheckCards { get; set; }
 
         public JudoPayApi(Func<Type, ILog> logger, IClient client)
         {
@@ -42,6 +43,7 @@ namespace JudoPayDotNet
             Collections = new Collections(logger(typeof(Collections)), client);
             ThreeDs = new ThreeDs(logger(typeof(ThreeDs)), client);
             RegisterCards = new RegisterCards(logger(typeof(RegisterCards)), client, true);
+            CheckCards = new CheckCards(logger(typeof(CheckCards)), client, true);
             SaveCards = new SaveCard(logger(typeof(SaveCard)), client);
             Voids = new Voids(logger(typeof(Voids)), client);
 

--- a/JudoPayDotNet/JudoPayApi.cs
+++ b/JudoPayDotNet/JudoPayApi.cs
@@ -28,8 +28,6 @@ namespace JudoPayDotNet
         public ITransactions Transactions { get; set; }
         public ICollections Collections { get; set; }
         public IThreeDs ThreeDs { get; set; }
-
-        [Obsolete("Register card is currently doing an authorisation to check that the card is valid. We now have two new methods. One is the save card, which doesnt check that a card is valid and check card, which checks if a card is valid. Neither do an authorisation")]
         public IRegisterCards RegisterCards { get; set; }
         public ISaveCard SaveCards { get; set; }
         public IVoids Voids { get; set; }

--- a/JudoPayDotNet/JudoPayApi.cs
+++ b/JudoPayDotNet/JudoPayApi.cs
@@ -28,6 +28,8 @@ namespace JudoPayDotNet
         public ITransactions Transactions { get; set; }
         public ICollections Collections { get; set; }
         public IThreeDs ThreeDs { get; set; }
+
+        [Obsolete("Register card is currently doing an authorisation to check that the card is valid. We now have two new methods. One is the save card, which doesnt check that a card is valid and check card, which checks if a card is valid. Neither do an authorisation")]
         public IRegisterCards RegisterCards { get; set; }
         public ISaveCard SaveCards { get; set; }
         public IVoids Voids { get; set; }

--- a/JudoPayDotNet/Models/CheckCardModel.cs
+++ b/JudoPayDotNet/Models/CheckCardModel.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace JudoPayDotNet.Models
+{
+    /// <summary>
+    /// Data to register a credit card
+    /// </summary>
+    [DataContract]
+    // ReSharper disable UnusedMember.Global
+    public class CheckCardModel : IModelWithHttpHeaders
+    {
+        public CheckCardModel()
+        {
+            YourPaymentReference = Guid.NewGuid().ToString();
+            HttpHeaders = new Dictionary<string, string>();
+        }
+
+        /// <summary>
+        /// Gets your payment reference.
+        /// </summary>
+        /// <value>
+        /// Your payment reference.
+        /// PLEASE NOTE!!!! there is a reflection call within JudoPayClient.cs that gets this property via a string call. update in both places
+        /// including  other model instances of yourPaymentReference ********************
+        /// </value>
+        [DataMember(EmitDefaultValue = false)]
+        public string YourPaymentReference { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets the CV2.
+        /// </summary>
+        /// <value>
+        /// The CV2.
+        /// </value>
+        [DataMember(EmitDefaultValue = false)]
+        public string CV2 { get; set; }
+
+        /// <summary>
+        /// Gets or sets the card number.
+        /// </summary>
+        /// <value>
+        /// The card number.
+        /// </value>
+        [DataMember(EmitDefaultValue = false)]
+        public string CardNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expiry date.
+        /// </summary>
+        /// <value>
+        /// The expiry date.
+        /// </value>
+        [DataMember(EmitDefaultValue = false)]
+        public string ExpiryDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start date.
+        /// </summary>
+        /// <value>
+        /// The start date.
+        /// </value>
+        [DataMember(IsRequired = false, EmitDefaultValue = false)]
+        public string StartDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Issue Number.
+        /// </summary>
+        /// <value>
+        /// The Issue Number date.
+        /// </value>
+        [DataMember(IsRequired = false)]
+        public string IssueNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the card address.
+        /// </summary>
+        /// <value>
+        /// The card address.
+        /// </value>
+        [DataMember(EmitDefaultValue = false)]
+        public CardAddressModel CardAddress { get; set; }
+
+        /// <summary>
+        /// Gets or sets your consumer reference.
+        /// </summary>
+        /// <value>
+        /// Your consumer reference.
+        /// </value>
+        [DataMember(EmitDefaultValue = false)]
+        public string YourConsumerReference { get; set; }
+
+        /// <summary>
+        /// Allows you to set HTTP headers on requests
+        /// </summary>
+        [IgnoreDataMember]
+        public Dictionary<string, string> HttpHeaders { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the judo identifier. This is the identifier that you can get from our portal
+        /// </summary>
+        /// <value>
+        /// This will be 6 or 9 digits
+        /// </value>
+        [DataMember(EmitDefaultValue = false)]
+        public string JudoId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the iso 3 character currency to be used in the transaction.
+        /// </summary>
+        /// <value>
+        /// GBP, EUR, USD
+        /// </value>
+        [DataMember(EmitDefaultValue = false)]
+        public string Currency { get; set; }
+    }
+    // ReSharper restore UnusedMember.Global
+}

--- a/JudoPayDotNet/Models/Validations/CheckCardValidator.cs
+++ b/JudoPayDotNet/Models/Validations/CheckCardValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+
+namespace JudoPayDotNet.Models.Validations
+{
+    internal class CheckCardValidator : AbstractValidator<CheckCardModel>
+    {
+        public CheckCardValidator()
+        {
+            RuleFor(model => model.YourConsumerReference)
+                .NotEmpty().WithMessage("You must supply your unique consumer reference")
+                .Length(1, 50).WithMessage("You unique consumer reference needs to be less than 50 characters.");
+
+            RuleFor(model => model.CardNumber)
+                .NotEmpty().WithMessage("You must supply your card number");
+
+            RuleFor(model => model.ExpiryDate)
+                .NotEmpty().WithMessage("You must supply your card expiry date");
+        }
+    }
+}

--- a/JudoPayDotNetIntegrationTests/CheckCardTests.cs
+++ b/JudoPayDotNetIntegrationTests/CheckCardTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading.Tasks;
+using JudoPayDotNet.Models;
+using NUnit.Framework;
+
+namespace JudoPayDotNetIntegrationTests
+{
+    [TestFixture]
+    public class CheckCardTests : IntegrationTestsBase
+    {
+        [Test]
+        public async Task CheckCard()
+        {
+            var checkCardModel = GetCheckCardModel(Configuration.Cybersource_Judoid);
+
+            var response = await JudoPayApiCyberSource.CheckCards.Create(checkCardModel);
+
+            Assert.IsNotNull(response);
+            Assert.IsFalse(response.HasError);
+            Assert.AreEqual("Success", response.Response.Result);
+
+            var receipt = response.Response as PaymentReceiptModel;
+            Assert.NotNull(receipt);
+            Assert.AreEqual("CheckCard", receipt.Type);
+        }
+
+        [Test]
+        public async Task CheckCardAndATokenPayment()
+        {
+            var checkCardModel = GetCheckCardModel(Configuration.Cybersource_Judoid);
+
+            var response = await JudoPayApiCyberSource.CheckCards.Create(checkCardModel);
+
+            Assert.IsNotNull(response);
+            Assert.IsFalse(response.HasError);
+
+            var receipt = response.Response as PaymentReceiptModel;
+
+            Assert.IsNotNull(receipt);
+            Assert.AreEqual("Success", receipt.Result);
+
+            // Fetch the card token
+            var cardToken = receipt.CardDetails.CardToken;
+            var consumerReference = receipt.Consumer.YourConsumerReference;
+            var paymentWithToken = GetTokenPaymentModel(cardToken, consumerReference, 27, judoId: Configuration.Cybersource_Judoid);
+
+            response = await JudoPayApiCyberSource.Payments.Create(paymentWithToken);
+
+            Assert.IsNotNull(response);
+            Assert.IsFalse(response.HasError);
+            Assert.AreEqual("Success", response.Response.Result);
+        }
+    }
+}

--- a/JudoPayDotNetIntegrationTests/Configuration.cs
+++ b/JudoPayDotNetIntegrationTests/Configuration.cs
@@ -11,9 +11,9 @@ namespace JudoPayDotNetIntegrationTests
         public string ElevatedPrivilegesToken = "90GEiHrgjEuHnbAt";
         public string Token = "Izx9omsBR15LatAl";
         public string Secret = "b5787124845533d8e68d12a586fa3713871b876b528600ebfdc037afec880cd6";
-        public string Cybersource_Judoid = "100986934";
-        public string Cybersource_Token = "os92LSyQe0Ywp2tE";
-        public string Cybersource_Secret = "d6110e7becd1a4f4b8d5d00e8cefbbf4342bf981270ea79325d73e68fb6e7d23";
+        public string Cybersource_Judoid = "100882208";
+        public string Cybersource_Token = "4jLqa8a5yoAZCir8";
+        public string Cybersource_Secret = "fce18777f015eee2f73abb7961b23320177994623fcc95643a7b39b8b155311f";
         public JudoEnvironment JudoEnvironment = JudoEnvironment.Sandbox;
     }
 }

--- a/JudoPayDotNetIntegrationTests/ConsumersTests.cs
+++ b/JudoPayDotNetIntegrationTests/ConsumersTests.cs
@@ -13,7 +13,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel("432438862");
 
-            var response = JudoPayApi.Payments.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.Payments.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -23,7 +23,7 @@ namespace JudoPayDotNetIntegrationTests
 
             Assert.IsNotNull(paymentReceipt);
 
-            var transactions = JudoPayApi.Consumers.GetTransactions(paymentReceipt.Consumer.ConsumerToken).Result;
+            var transactions = JudoPayApiIridium.Consumers.GetTransactions(paymentReceipt.Consumer.ConsumerToken).Result;
 
             Assert.IsNotNull(transactions);
             Assert.IsFalse(transactions.HasError);
@@ -39,7 +39,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel("432438862");
 
-            var response = JudoPayApi.Payments.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.Payments.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -49,7 +49,7 @@ namespace JudoPayDotNetIntegrationTests
 
             Assert.IsNotNull(paymentReceipt);
 
-            var transactions = JudoPayApi.Consumers.GetPayments(paymentReceipt.Consumer.ConsumerToken).Result;
+            var transactions = JudoPayApiIridium.Consumers.GetPayments(paymentReceipt.Consumer.ConsumerToken).Result;
 
             Assert.IsNotNull(transactions);
             Assert.IsFalse(transactions.HasError);
@@ -65,7 +65,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel("432438862");
 
-            var response = JudoPayApi.PreAuths.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.PreAuths.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -75,7 +75,7 @@ namespace JudoPayDotNetIntegrationTests
 
             Assert.IsNotNull(paymentReceipt);
 
-            var transactions = JudoPayApi.Consumers.GetPreAuths(paymentReceipt.Consumer.ConsumerToken).Result;
+            var transactions = JudoPayApiIridium.Consumers.GetPreAuths(paymentReceipt.Consumer.ConsumerToken).Result;
 
             Assert.IsNotNull(transactions);
             Assert.IsFalse(transactions.HasError);
@@ -91,7 +91,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel("432438862");
 
-            var response = JudoPayApi.PreAuths.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.PreAuths.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -104,7 +104,7 @@ namespace JudoPayDotNetIntegrationTests
                 
             };
 
-            response = JudoPayApi.Collections.Create(collection).Result;
+            response = JudoPayApiIridium.Collections.Create(collection).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -114,7 +114,7 @@ namespace JudoPayDotNetIntegrationTests
 
             Assert.IsNotNull(paymentReceipt);
 
-            var transactions = JudoPayApi.Consumers.GetCollections(paymentReceipt.Consumer.ConsumerToken).Result;
+            var transactions = JudoPayApiIridium.Consumers.GetCollections(paymentReceipt.Consumer.ConsumerToken).Result;
 
             Assert.IsNotNull(transactions);
             Assert.IsFalse(transactions.HasError);
@@ -130,7 +130,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel("432438862");
 
-            var paymentResponse = JudoPayApi.Payments.Create(paymentWithCard).Result;
+            var paymentResponse = JudoPayApiIridium.Payments.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(paymentResponse);
             Assert.IsFalse(paymentResponse.HasError);
@@ -143,7 +143,7 @@ namespace JudoPayDotNetIntegrationTests
                 
             };
 
-            var response = JudoPayApi.Refunds.Create(refund).Result;
+            var response = JudoPayApiIridium.Refunds.Create(refund).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -153,7 +153,7 @@ namespace JudoPayDotNetIntegrationTests
 
             Assert.IsNotNull(paymentReceipt);
 
-            var transactions = JudoPayApi.Consumers.GetRefunds(paymentReceipt.Consumer.ConsumerToken).Result;
+            var transactions = JudoPayApiIridium.Consumers.GetRefunds(paymentReceipt.Consumer.ConsumerToken).Result;
 
             Assert.IsNotNull(transactions);
             Assert.IsFalse(transactions.HasError);

--- a/JudoPayDotNetIntegrationTests/IntegrationTestsBase.cs
+++ b/JudoPayDotNetIntegrationTests/IntegrationTestsBase.cs
@@ -15,14 +15,16 @@ namespace JudoPayDotNetIntegrationTests
 {
     public abstract class IntegrationTestsBase
     {
-        protected JudoPayApi JudoPayApi;
+        protected JudoPayApi JudoPayApiIridium;
+        protected JudoPayApi JudoPayApiCyberSource;
         protected JudoPayApi JudoPayApiElevated;
         protected readonly Configuration Configuration = new Configuration();
 
         protected IntegrationTestsBase() 
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            JudoPayApi = JudoPaymentsFactory.Create(Configuration.JudoEnvironment, Configuration.Token, Configuration.Secret);
+            JudoPayApiIridium = JudoPaymentsFactory.Create(Configuration.JudoEnvironment, Configuration.Token, Configuration.Secret);
+            JudoPayApiCyberSource = JudoPaymentsFactory.Create(Configuration.JudoEnvironment, Configuration.Cybersource_Token, Configuration.Cybersource_Secret);
             JudoPayApiElevated = JudoPaymentsFactory.Create(Configuration.JudoEnvironment, Configuration.ElevatedPrivilegesToken, Configuration.ElevatedPrivilegesSecret);
         }
 
@@ -79,14 +81,15 @@ namespace JudoPayDotNetIntegrationTests
             };
         }
 
-        protected TokenPaymentModel GetTokenPaymentModel(string cardToken, string yourConsumerReference = null, decimal amount = 25, bool? recurringPayment = null)
+        protected TokenPaymentModel GetTokenPaymentModel(string cardToken, string yourConsumerReference = null, decimal amount = 25,
+            bool? recurringPayment = null, string judoId = null)
         {
             if (string.IsNullOrEmpty(yourConsumerReference))
                 yourConsumerReference = Guid.NewGuid().ToString();
 
             return new TokenPaymentModel
             {
-                JudoId = Configuration.Judoid,
+                JudoId = judoId ?? Configuration.Judoid,
                 YourConsumerReference = yourConsumerReference,
                 Amount = amount,
                 CardToken = cardToken,
@@ -96,27 +99,29 @@ namespace JudoPayDotNetIntegrationTests
             };
         }
 
+        protected CheckCardModel GetCheckCardModel(string judoId = null, string cardNumber = "4976000000003436", string cv2 = "452")
+        {
+           var yourConsumerReference = Guid.NewGuid().ToString();
+
+            return new CheckCardModel
+            {
+                JudoId = judoId ?? Configuration.Judoid,
+                YourConsumerReference = yourConsumerReference,
+                CardNumber = cardNumber,
+                CV2 = cv2,
+                ExpiryDate = "12/20",
+                CardAddress = new CardAddressModel
+                {
+                    Line1 = "32 Edward Street",
+                    PostCode = "TR14 8PA",
+                    Town = "Camborne"
+                }
+            };
+        }
+
         protected async Task<OneTimePaymentModel> GetOneTimePaymentModel()
         {
-            var client = new HttpClient();
-            client.DefaultRequestHeaders.Add("Api-Version", VersioningHandler.DEFAULT_API_VERSION);
-            client.DefaultRequestHeaders.Add("Authorization", $"Simple {Configuration.Token}");
-
-            var cardDetailsModel = new Dictionary<string, string>
-            {
-                { "cardNumber", "4976000000003436" },
-                { "expiryDate", "1220" },
-                { "cV2", "452" },
-            };
-            var message = new HttpRequestMessage
-            {
-                Content = new StringContent(JsonConvert.SerializeObject(cardDetailsModel), Encoding.UTF8, "application/json"),
-                Method = HttpMethod.Post,
-                RequestUri = new Uri(JudoPaymentsFactory.GetEnvironmentUrl(Configuration.JudoEnvironment) + "/encryptions/paymentdetails")
-            };
-
-            var response = await client.SendAsync(message);
-            var oneUseTokenModel = JsonConvert.DeserializeObject<OneUseTokenModel>(await response.Content.ReadAsStringAsync());
+            var oneUseTokenModel = await GetOneUseToken();
 
             return new OneTimePaymentModel
             {
@@ -133,7 +138,31 @@ namespace JudoPayDotNetIntegrationTests
             };
         }
 
-        class OneUseTokenModel
+        private async Task<OneUseTokenModel> GetOneUseToken()
+        {
+            var client = new HttpClient();
+            client.DefaultRequestHeaders.Add("Api-Version", VersioningHandler.DEFAULT_API_VERSION);
+            client.DefaultRequestHeaders.Add("Authorization", $"Simple {Configuration.Token}");
+
+            var cardDetailsModel = new Dictionary<string, string>
+            {
+                {"cardNumber", "4976000000003436"},
+                {"expiryDate", "1220"},
+                {"cV2", "452"},
+            };
+            var message = new HttpRequestMessage
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(cardDetailsModel), Encoding.UTF8, "application/json"),
+                Method = HttpMethod.Post,
+                RequestUri = new Uri(JudoPaymentsFactory.GetEnvironmentUrl(Configuration.JudoEnvironment) + "/encryptions/paymentdetails")
+            };
+
+            var response = await client.SendAsync(message);
+            var oneUseTokenModel = JsonConvert.DeserializeObject<OneUseTokenModel>(await response.Content.ReadAsStringAsync());
+            return oneUseTokenModel;
+        }
+
+        private class OneUseTokenModel
         {
             public string OneUseToken { get; set; }
         }
@@ -182,11 +211,6 @@ namespace JudoPayDotNetIntegrationTests
                     EncryptedPaymentData = encPaymentData
                 }
             };
-        }
-
-        protected JudoPayApi UseCybersourceGateway()
-        {
-            return JudoPaymentsFactory.Create(Configuration.JudoEnvironment, Configuration.Cybersource_Token, Configuration.Cybersource_Secret);
         }
     }
 }

--- a/JudoPayDotNetIntegrationTests/PaymentTest.cs
+++ b/JudoPayDotNetIntegrationTests/PaymentTest.cs
@@ -13,7 +13,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel();
 
-            var response = await JudoPayApi.Payments.Create(paymentWithCard);
+            var response = await JudoPayApiIridium.Payments.Create(paymentWithCard);
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -46,15 +46,14 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel(recurringPayment: true, judoId: Configuration.Cybersource_Judoid);
 
-            var judoPay = UseCybersourceGateway();
-
-            var response = await judoPay.Payments.Create(paymentWithCard);
+            var response = await JudoPayApiCyberSource.Payments.Create(paymentWithCard);
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
             Assert.AreEqual("Success", response.Response.Result);
+
             var paymentReceipt = response.Response as PaymentReceiptModel;
-            Assert.IsInstanceOf<PaymentReceiptModel>(response.Response);
+            Assert.IsNotNull(paymentReceipt);
             Assert.IsTrue(paymentReceipt.Recurring);
         }
 
@@ -64,7 +63,7 @@ namespace JudoPayDotNetIntegrationTests
             var consumerReference = Guid.NewGuid().ToString();
             var paymentWithCard = GetCardPaymentModel(consumerReference);
 
-            var response = await JudoPayApi.Payments.Create(paymentWithCard);
+            var response = await JudoPayApiIridium.Payments.Create(paymentWithCard);
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -79,7 +78,7 @@ namespace JudoPayDotNetIntegrationTests
             var cardToken = receipt.CardDetails.CardToken;
 
             var paymentWithToken = GetTokenPaymentModel(cardToken, consumerReference, 26);
-            response = await JudoPayApi.Payments.Create(paymentWithToken);
+            response = await JudoPayApiIridium.Payments.Create(paymentWithToken);
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -114,9 +113,7 @@ namespace JudoPayDotNetIntegrationTests
 
             var paymentWithCard = GetCardPaymentModel(consumerReference, recurringPayment: true, judoId: Configuration.Cybersource_Judoid);
 
-            var judoPay = UseCybersourceGateway();
-
-            var response = await judoPay.Payments.Create(paymentWithCard);
+            var response = await JudoPayApiCyberSource.Payments.Create(paymentWithCard);
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -136,7 +133,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var oneTimePaymentModel = GetOneTimePaymentModel().Result;
 
-            var response = await JudoPayApi.Payments.Create(oneTimePaymentModel);
+            var response = await JudoPayApiIridium.Payments.Create(oneTimePaymentModel);
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -152,7 +149,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel("432438862", "4221690000004963", "125");
 
-            var response = await JudoPayApi.Payments.Create(paymentWithCard);
+            var response = await JudoPayApiIridium.Payments.Create(paymentWithCard);
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -164,9 +161,9 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel("432438862");
 
-            var response1 = await JudoPayApi.Payments.Create(paymentWithCard);
+            var response1 = await JudoPayApiIridium.Payments.Create(paymentWithCard);
 
-            var response2 = await JudoPayApi.Payments.Create(paymentWithCard);
+            var response2 = await JudoPayApiIridium.Payments.Create(paymentWithCard);
 
             Assert.AreEqual(response1.Response.ReceiptId, response2.Response.ReceiptId);
         }
@@ -179,7 +176,7 @@ namespace JudoPayDotNetIntegrationTests
             var encPaymentData = "EuWD12Sem0WTNRbIsCG6ATsABxssMvbPvFbR8SqK1Jj7YeU6a7s9Bs2Gk7I94E9p6ghEvl/wePm9nhamebj7vBzdLj/ezOqBgl41JUNq+uhRfS5zB9+7nAZkldwpT9TaLECbb+4JY1W9osUoZXL7XtnKz+OTeBG3apnjDomVf9kaNpbu0RkQFzclTyoeeODTDtpoZ+lqumR1E7yr/LsG5JtM+GvAdoULSgX3Xc4IaCRCWbGwKZaTm8PadXuyPiZXpcRCZd0I0KBDj8RGHW7wl3rPfpx4SxB4YMBieJNFbdj/AU2hWnU8fYEtgPaWKaA31a4csHFvQSBsmGAuJLEQ7CKb63k1EZV7rMJR/If/jNz17gtVHWjaEb/SNHybHe7MzDkmjhODfFR+ceaHb9b/NwD1X9QGBXSwrXwMZR06vdyao//T44NbhhfPngGORSz47sHx2o40ECIfo5HGB/BbZO48Sl61pNKommEjEj0JabbzOqNEdA7IJkf1I1eO0bPTW41Vd84Fgofe2aKy2987lPhMnJdHFaslo6DS8cclF7LySQWYjOZNSL+0tW9hLLV1DO1H0xvYA7CsvHyutyDxTVtiOkl5+MKeAzRsaWQTC4sbxrgWZjYbxGCeWOWED+xQRSeJmY1J4hpUjB7jwGymekBXVfiHvwM9sAgZ2+EU95j6kRYciKhLOMgYH68wRJqHR4wR4rjxiHrjwZARqnG/5vwYZ9qvJxyKUkE+lcMNLK8x18tT4N1nm2oPW08GnbkRXmr2SFnv3RwuxbIOyaKIJrNjeQ0ybG4+taQcdRyllNpKwY04sxN3seC5w4/85x302oVzpaJAM22SIqawTn20kKIQylJI3X/w+LoPHthrGdT56mLAntjIB0P4Wnz1l2APaXfgtvKyX5HoM7acgTucEFKfiWEeBMcamu9XqSBQWELTXQls6CDTNrcAM2X4oEJSUaacTarCVWUmrluuNr+AO3YF9NMil35ES+P6+/Z0ikWqi5OFxNTy3milrsyjwEakmRS7J3/hMhAkcVmG7vUeBqSYmqa+p3KcL+0R1pjv//eh6Zw5gj7LHmgEmsuNmdUyW/kw19ekCU2ToLUpFtS64PUUB0lvFXP/abX2zEjzEYmYwhtr1Bgt3AAlc+z4LucUFm9m2jYWW+dbv5ivHHlGcLD8qJi455rQGzu316mFYUeAQ6nQmza6MYWQ2UvaCm38f5F7VOzMWrW447whNtKpXAb8DUDGUiXglwChXeEyc7UEmYDuy2XD1iEt3x8s38pOGjePXVu5ItyD2IV4jD/U4DwzYvByRzErQLZglLeWoqoeGsINXecu4PIoNgfnt8VLVjVwsI54IuNkkjk9KPQ/BqYQoPV2SzAhGDV69BK9KntnlKhPsdLcPNLEXLHn9nYLobFpFj4Gha1oxSQ4KwU8oNYvypXWZ17cp2LPbbYeRpjygHGwIVait8x8ztF9EXDBFC28V6WpQKjlKpKcAQooZs3JjYPXqhaUrMEgpBCRthtB434SXQo3v82CltQYOXQiOgvrWWjf67vVSOojqJRzqzNqC2v7HNvAzjKXccCfO1SzomzHKan86hvDJBmjPR7UhV/qtNuIFL9bh/WBHZEKRDdNuGQMzAl9vO7V096tuCCtOlqjy4ICXY/eC7M3mtydSFyVrKShcUHwmBOaB2bnQcXd8sQaT9kcihjmRWd+P8t2O53vAavMmUSdGu0Hb+BS5uw/yW41ne3kUbhm6L6bFy/BiNEwNsKLyen4K1lvGsTgwFUD64lpPurWWzFTXhffqSKPIPqWxhoDMBWU46DmxsBXevzUNsq2mR5zWcB1kGpuR3uJHEZ4zc+CThqAPsKchFC+uGahCE+jldbcvGQE3RCzdzZRmyjxe4jttuExhLE=";
             var paymentWithCard = GetVisaCheckoutPaymentModel(callId, encKey, encPaymentData);
 
-            var response = await JudoPayApi.Payments.Create(paymentWithCard);
+            var response = await JudoPayApiIridium.Payments.Create(paymentWithCard);
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);

--- a/JudoPayDotNetIntegrationTests/PreAuthAndCollectionTests.cs
+++ b/JudoPayDotNetIntegrationTests/PreAuthAndCollectionTests.cs
@@ -11,7 +11,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel("432438862");
 
-            var response = JudoPayApi.PreAuths.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.PreAuths.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -29,7 +29,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var oneTimePaymentModel = GetOneTimePaymentModel().Result;
 
-            var response = JudoPayApi.PreAuths.Create(oneTimePaymentModel).Result;
+            var response = JudoPayApiIridium.PreAuths.Create(oneTimePaymentModel).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -45,7 +45,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel("432438862", "4221690000004963", "125");
 
-            var response = JudoPayApi.PreAuths.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.PreAuths.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -57,7 +57,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel();
 
-            var response = JudoPayApi.PreAuths.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.PreAuths.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -76,7 +76,7 @@ namespace JudoPayDotNetIntegrationTests
                 
             };
 
-            response = JudoPayApi.Collections.Create(collection).Result;
+            response = JudoPayApiIridium.Collections.Create(collection).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -94,7 +94,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel("432438862");
 
-            var response = JudoPayApi.PreAuths.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.PreAuths.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -112,13 +112,13 @@ namespace JudoPayDotNetIntegrationTests
                 ReceiptId = response.Response.ReceiptId,
             };
 
-            var collectionResponse = JudoPayApi.Collections.Create(collection).Result;
+            var collectionResponse = JudoPayApiIridium.Collections.Create(collection).Result;
 
             // The collection will go through since it is less than the preauth amount
             Assert.That(collectionResponse.HasError, Is.False);
             Assert.That(collectionResponse.Response.ReceiptId, Is.GreaterThan(0));
 
-            var validateResponse = JudoPayApi.Collections.Create(collection).Result;
+            var validateResponse = JudoPayApiIridium.Collections.Create(collection).Result;
 
             Assert.That(validateResponse, Is.Not.Null);
             Assert.That(validateResponse.HasError, Is.True);
@@ -131,7 +131,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel();
 
-            var response = JudoPayApi.PreAuths.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.PreAuths.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -149,7 +149,7 @@ namespace JudoPayDotNetIntegrationTests
                 ReceiptId = response.Response.ReceiptId,
             };
 
-            response = JudoPayApi.Voids.Create(voidPreAuth).Result;
+            response = JudoPayApiIridium.Voids.Create(voidPreAuth).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);

--- a/JudoPayDotNetIntegrationTests/RefundsTests.cs
+++ b/JudoPayDotNetIntegrationTests/RefundsTests.cs
@@ -10,7 +10,7 @@ namespace JudoPayDotNetIntegrationTests
         public void ASimplePaymentAndRefund()
         {
             var paymentWithCard = GetCardPaymentModel();
-            var response = JudoPayApi.Payments.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.Payments.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -23,7 +23,7 @@ namespace JudoPayDotNetIntegrationTests
                
             };
 
-            response = JudoPayApi.Refunds.Create(refund).Result;
+            response = JudoPayApiIridium.Refunds.Create(refund).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -41,7 +41,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel("432438862");
 
-            var preAuthResponse = JudoPayApi.PreAuths.Create(paymentWithCard).Result;
+            var preAuthResponse = JudoPayApiIridium.PreAuths.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(preAuthResponse);
             Assert.IsFalse(preAuthResponse.HasError);
@@ -54,7 +54,7 @@ namespace JudoPayDotNetIntegrationTests
                 
             };
 
-            var collection1Response = JudoPayApi.Collections.Create(collection).Result;
+            var collection1Response = JudoPayApiIridium.Collections.Create(collection).Result;
 
             Assert.IsNotNull(collection1Response);
             Assert.IsFalse(collection1Response.HasError);
@@ -73,7 +73,7 @@ namespace JudoPayDotNetIntegrationTests
                 
             };
 
-            var collection2Response = JudoPayApi.Collections.Create(collection).Result;
+            var collection2Response = JudoPayApiIridium.Collections.Create(collection).Result;
 
             Assert.IsNotNull(collection2Response);
             Assert.IsFalse(collection2Response.HasError);
@@ -92,7 +92,7 @@ namespace JudoPayDotNetIntegrationTests
                 
             };
 
-            var response = JudoPayApi.Refunds.Create(refund).Result;
+            var response = JudoPayApiIridium.Refunds.Create(refund).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -111,7 +111,7 @@ namespace JudoPayDotNetIntegrationTests
                 
             };
 
-            response = JudoPayApi.Refunds.Create(refund).Result;
+            response = JudoPayApiIridium.Refunds.Create(refund).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);

--- a/JudoPayDotNetIntegrationTests/RegisterCardTests.cs
+++ b/JudoPayDotNetIntegrationTests/RegisterCardTests.cs
@@ -15,7 +15,7 @@ namespace JudoPayDotNetIntegrationTests
 
             var registerCardModel = GetRegisterCardModel("432438862");
 
-            var response = await JudoPayApi.RegisterCards.Create(registerCardModel);
+            var response = await JudoPayApiIridium.RegisterCards.Create(registerCardModel);
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -29,7 +29,7 @@ namespace JudoPayDotNetIntegrationTests
 
             var registerCard = GetRegisterCardModel(consumerReference);
 
-            var response = await JudoPayApi.RegisterCards.Create(registerCard);
+            var response = await JudoPayApiIridium.RegisterCards.Create(registerCard);
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -45,7 +45,7 @@ namespace JudoPayDotNetIntegrationTests
 
             var paymentWithToken = GetTokenPaymentModel(cardToken, consumerReference, 27);
 
-            response = await JudoPayApi.Payments.Create(paymentWithToken);
+            response = await JudoPayApiIridium.Payments.Create(paymentWithToken);
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -57,7 +57,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var registerCard = GetRegisterCardModel("432438862", "4221690000004963", "125");
 
-            var response = JudoPayApi.RegisterCards.Create(registerCard).Result;
+            var response = JudoPayApiIridium.RegisterCards.Create(registerCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);

--- a/JudoPayDotNetIntegrationTests/SaveCardTests.cs
+++ b/JudoPayDotNetIntegrationTests/SaveCardTests.cs
@@ -12,7 +12,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var registerCardModel = GetCardPaymentModel("432438862");
 
-            var response = JudoPayApi.SaveCards.Create(registerCardModel).Result;
+            var response = JudoPayApiIridium.SaveCards.Create(registerCardModel).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -24,7 +24,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var registerCardModel = GetCardPaymentModel("432438862", "4976000000003436", null);
 
-            var response = JudoPayApi.SaveCards.Create(registerCardModel).Result;
+            var response = JudoPayApiIridium.SaveCards.Create(registerCardModel).Result;
 
             Assert.IsNotNull(response);
             Assert.IsTrue(response.HasError);
@@ -37,7 +37,7 @@ namespace JudoPayDotNetIntegrationTests
 
             var registerCard = GetCardPaymentModel(consumerReference);
 
-            var response = JudoPayApi.SaveCards.Create(registerCard).Result;
+            var response = JudoPayApiIridium.SaveCards.Create(registerCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -53,11 +53,11 @@ namespace JudoPayDotNetIntegrationTests
 
             var paymentWithToken = GetTokenPaymentModel(cardToken, consumerReference, 26);
 
-            response = JudoPayApi.Payments.Create(paymentWithToken).Result;
+            response = JudoPayApiIridium.Payments.Create(paymentWithToken).Result;
 
             paymentWithToken = GetTokenPaymentModel(cardToken, consumerReference, 27);
 
-            response = JudoPayApi.Payments.Create(paymentWithToken).Result;
+            response = JudoPayApiIridium.Payments.Create(paymentWithToken).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);

--- a/JudoPayDotNetIntegrationTests/ThreeDAuthorizationTests.cs
+++ b/JudoPayDotNetIntegrationTests/ThreeDAuthorizationTests.cs
@@ -19,7 +19,7 @@ namespace JudoPayDotNetIntegrationTests
             paymentWithCard.AcceptHeaders = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8";
             paymentWithCard.DeviceCategory = "Mobile";
 
-            var response = JudoPayApi.Payments.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.Payments.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -41,7 +41,7 @@ namespace JudoPayDotNetIntegrationTests
             paymentWithCard.AcceptHeaders = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8";
             paymentWithCard.DeviceCategory = "Mobile";
             
-            var response = JudoPayApi.Payments.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.Payments.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -74,7 +74,7 @@ namespace JudoPayDotNetIntegrationTests
 
                 Assert.That(paResValue, Is.Not.Empty);
 
-                var threeDResult = JudoPayApi.ThreeDs.Complete3DSecure(receipt.ReceiptId, new ThreeDResultModel { PaRes = paResValue }).Result;
+                var threeDResult = JudoPayApiIridium.ThreeDs.Complete3DSecure(receipt.ReceiptId, new ThreeDResultModel { PaRes = paResValue }).Result;
 
                 Assert.IsNotNull(threeDResult);
                 Assert.IsFalse(threeDResult.HasError);

--- a/JudoPayDotNetIntegrationTests/TransactionTest.cs
+++ b/JudoPayDotNetIntegrationTests/TransactionTest.cs
@@ -12,13 +12,13 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel("432438862");
 
-            var response = JudoPayApi.Payments.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.Payments.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
             Assert.AreEqual("Success", response.Response.Result);
 
-            var transaction = JudoPayApi.Transactions.Get(response.Response.ReceiptId).Result;
+            var transaction = JudoPayApiIridium.Transactions.Get(response.Response.ReceiptId).Result;
 
             Assert.IsNotNull(transaction);
             Assert.IsFalse(transaction.HasError);
@@ -31,7 +31,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel();
 
-            var response = JudoPayApi.PreAuths.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.PreAuths.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
@@ -44,10 +44,10 @@ namespace JudoPayDotNetIntegrationTests
                 
             };
 
-            var collectionResult = JudoPayApi.Collections.Create(collection).Result;
-            collectionResult = JudoPayApi.Collections.Create(collection).Result;
+            var collectionResult = JudoPayApiIridium.Collections.Create(collection).Result;
+            collectionResult = JudoPayApiIridium.Collections.Create(collection).Result;
 
-            var transaction = JudoPayApi.Transactions.Get(response.Response.ReceiptId).Result;
+            var transaction = JudoPayApiIridium.Transactions.Get(response.Response.ReceiptId).Result;
 
             var payment = transaction.Response as PaymentReceiptModel;
 
@@ -64,13 +64,13 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel("66666666");
 
-            var response = JudoPayApi.Payments.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.Payments.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
             Assert.AreEqual("Success", response.Response.Result);
             System.Threading.Thread.Sleep(1000);
-            var transaction = JudoPayApi.Transactions.Get().Result;
+            var transaction = JudoPayApiIridium.Transactions.Get().Result;
 
             Assert.IsNotNull(transaction);
             Assert.IsFalse(transaction.HasError);
@@ -83,13 +83,13 @@ namespace JudoPayDotNetIntegrationTests
         {
             var paymentWithCard = GetCardPaymentModel("432438862");
 
-            var response = JudoPayApi.Payments.Create(paymentWithCard).Result;
+            var response = JudoPayApiIridium.Payments.Create(paymentWithCard).Result;
 
             Assert.IsNotNull(response);
             Assert.IsFalse(response.HasError);
             Assert.AreEqual("Success", response.Response.Result);
             System.Threading.Thread.Sleep(1000);
-            var transaction = JudoPayApi.Transactions.Get(TransactionType.PAYMENT).Result;
+            var transaction = JudoPayApiIridium.Transactions.Get(TransactionType.PAYMENT).Result;
 
             Assert.IsNotNull(transaction);
             Assert.IsFalse(transaction.HasError);

--- a/JudoPayDotNetIntegrationTests/WebPaymentsTests.cs
+++ b/JudoPayDotNetIntegrationTests/WebPaymentsTests.cs
@@ -120,7 +120,7 @@ namespace JudoPayDotNetIntegrationTests
         {
             var request = GetWebPaymentRequestModel();
 
-            var result = JudoPayApi.WebPayments.Payments.Create(request).Result;
+            var result = JudoPayApiIridium.WebPayments.Payments.Create(request).Result;
 
             var reference = result.Response.Reference;
 
@@ -188,7 +188,7 @@ namespace JudoPayDotNetIntegrationTests
 
             var receiptId = formField.GetAttributeValue("value", "");
 
-            var webRequest = JudoPayApi.WebPayments.Transactions.GetByReceipt(receiptId).Result;
+            var webRequest = JudoPayApiIridium.WebPayments.Transactions.GetByReceipt(receiptId).Result;
 
             Assert.NotNull(webRequest);
             Assert.IsFalse(webRequest.HasError);


### PR DESCRIPTION
We have a new endpoint for check card. This allows us to check whether the card is valid or not without having to do an authorisation. This is only currently available on the CyberSource platform. So I have updated the credentials to be under our test account.