### PR TITLE
Updating Nuget API Key

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ deploy:
 - provider: NuGet
   artifact: /.*\.nupkg/
   api_key:
-    secure: Xrdb/1KMY1mzzgXpW+/pnHel151dczxcPWmWrrhJBzF+HMjNIdM+3C2QqWECA6ns
+    secure: oy2fx7esukdmp4bx7iiarpof4wlr3o4elbzjdurqujb7mq
   on:
     APPVEYOR_REPO_TAG: true
 notifications:


### PR DESCRIPTION
Nuget API key expired, causing this error:

"Error publishing package. NuGet server returned 403: The specified API key is invalid, has expired, or does not have permission to access the specified package."