### PR TITLE
JR-4132 : Switch default urls to api.judopay.com and api-sandbox.judopay.com with certificate checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## Changes on 2020-06-05
+## Changes for (v3.0)
+- Update default base Urls with certificate pinning checks
+
+## Changes on 2020-10-21 (v2.1.237)
+- Updated the following models to allow custom values for YourPaymentReference (1 to 50 characters)
+	- PaymentModel
+	- SaveCardModel
+	- CheckCardModel
+	- RegisterCardModel
+
+## Changes on 2020-06-05 (v2.1.223)
 #### Added
 - PostCodeCheckResult, KountTransactionId, AcquirerTransactionId, ExternalBankResponseCode and BillingAddress to PaymentReceiptModel
 
@@ -12,7 +22,7 @@ All notable changes to this project will be documented in this file.
 - Added one time token payment
 
 ## Changes on 2018-03-01
-- Removed cliend side validation for transactions with 0 amount
+- Removed client side validation for transactions with 0 amount
 
 ## Changes on 2017-04-04
 

--- a/JudoPayDotNet.sln
+++ b/JudoPayDotNet.sln
@@ -14,7 +14,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 		appveyor.yml = appveyor.yml
 		CHANGELOG.md = CHANGELOG.md
 		Deploy.md = Deploy.md
+		Readme.md = Readme.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JudoPayDotNetSampleApp", "JudoPayDotNetSampleApp\JudoPayDotNetSampleApp.csproj", "{69122E3D-120B-43CD-A710-5091792CF323}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -50,6 +53,18 @@ Global
 		{D6F57848-85CD-44D1-A4AC-6C0E0E918061}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D6F57848-85CD-44D1-A4AC-6C0E0E918061}.Release|ARM.ActiveCfg = Release|Any CPU
 		{D6F57848-85CD-44D1-A4AC-6C0E0E918061}.Release|x86.ActiveCfg = Release|Any CPU
+		{69122E3D-120B-43CD-A710-5091792CF323}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69122E3D-120B-43CD-A710-5091792CF323}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69122E3D-120B-43CD-A710-5091792CF323}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{69122E3D-120B-43CD-A710-5091792CF323}.Debug|ARM.Build.0 = Debug|Any CPU
+		{69122E3D-120B-43CD-A710-5091792CF323}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{69122E3D-120B-43CD-A710-5091792CF323}.Debug|x86.Build.0 = Debug|Any CPU
+		{69122E3D-120B-43CD-A710-5091792CF323}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69122E3D-120B-43CD-A710-5091792CF323}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69122E3D-120B-43CD-A710-5091792CF323}.Release|ARM.ActiveCfg = Release|Any CPU
+		{69122E3D-120B-43CD-A710-5091792CF323}.Release|ARM.Build.0 = Release|Any CPU
+		{69122E3D-120B-43CD-A710-5091792CF323}.Release|x86.ActiveCfg = Release|Any CPU
+		{69122E3D-120B-43CD-A710-5091792CF323}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/JudoPayDotNet.sln.startup.json
+++ b/JudoPayDotNet.sln.startup.json
@@ -1,0 +1,55 @@
+/*
+    This is a configuration file for the SwitchStartupProject Visual Studio Extension
+    See https://bitbucket.org/thirteen/switchstartupproject/src/tip/Configuration.md
+*/
+{
+    /*  Configuration File Version  */
+    "Version": 3,
+    
+    /*  Create an item in the dropdown list for each project in the solution?  */
+    "ListAllProjects": true,
+
+    /*
+        Dictionary of named configurations with one or multiple startup projects
+        and optional parameters like command line arguments and working directory.
+        Example:
+
+        "MultiProjectConfigurations": {
+          "A + B (Ext)": {
+            "Projects": {
+              "MyProjectA": {},
+              "MyProjectB": {
+                "CommandLineArguments": "1234",
+                "WorkingDirectory": "%USERPROFILE%\\test",
+                "StartExternalProgram": "c:\\myprogram.exe"
+              }
+            }
+          },
+          "A + B": {
+            "Projects": {
+              "MyProjectA": {},
+              "MyProjectB": {
+                "CommandLineArguments": "",
+                "WorkingDirectory": "",
+                "StartProject": true
+              }
+            }
+          },
+          "D (Debug x86)": {
+            "Projects": {
+              "MyProjectD": {}
+            },
+            "SolutionConfiguration": "Debug",
+            "SolutionPlatform": "x86",
+          },
+          "D (Release x64)": {
+            "Projects": {
+              "MyProjectD": {}
+            },
+            "SolutionConfiguration": "Release",
+            "SolutionPlatform": "x64",
+          }
+        }
+    */
+    "MultiProjectConfigurations": {}
+}

--- a/JudoPayDotNet/Http/VersioningHandler.cs
+++ b/JudoPayDotNet/Http/VersioningHandler.cs
@@ -4,16 +4,14 @@ using System.Threading.Tasks;
 
 namespace JudoPayDotNet.Http
 {
-    using System.Reflection;
-
     /// <summary>
-    /// The JudoPay API supports multiple api versions, this handler adds the "API-Version" header to requests
+    /// The JudoPay API supports multiple API versions, this handler adds the "API-Version" header to requests
     /// </summary>
     internal class VersioningHandler : DelegatingHandler
     {
         public const string API_VERSION_HEADER = "api-version";
 
-        internal const string DEFAULT_API_VERSION = "5.6.0.0";
+        internal const string DEFAULT_API_VERSION = "5.10.0.0";
 
         private readonly string _apiVersionValue;
 

--- a/JudoPayDotNet/JudoPaymentsFactory.cs
+++ b/JudoPayDotNet/JudoPaymentsFactory.cs
@@ -12,25 +12,39 @@ namespace JudoPayDotNet
     using System.Collections.Generic;
     using System.Net.Http.Headers;
 
-    using JudoPayDotNet.Clients;
-
     // ReSharper disable UnusedMember.Global
     /// <summary>
     /// This factory creates an instance of the JudoPay client using the supplied credentials
     /// </summary>
     public static class JudoPaymentsFactory
     {
-        private const string DEFAULT_SANDBOX_URL = "https://gw1.judopay-sandbox.com/";
+        // Future state will use https://api-sandbox.judopay.com/ with *.judopay.com certificate
+        private const string DefaultSandboxUrl = "https://gw1.judopay-sandbox.com/";
 
-        private const string DEFAULT_LIVE_URL = "https://gw1.judopay.com/";
+        // Future state will use https://api.judopay.com/ with *.judopay.com certificate
+        private const string DefaultLiveUrl = "https://gw1.judopay.com/";
         
-        private const string LiveCertificatePublicKey = "MIIBCgKCAQEAqyx7Fg8FkI7Q2yaai//AXURuithFkoPfBliXOpGQ8O8vo+foXTLVpWmStnCUfzhm5dIJEgKn/FVK+/M5vGQSJ+aqhAL6A9Eq+UazOY2X65QweOQiQmcC6WELYBO+wx8oXQLp/PVYLlAfaljFRBqo3c4kfeLwd4VISJuFs941B7vTrkgZ0t6TSbnwUZNpSLr53pNyR4QJ/OSPsoxtdec7z+38dPUW0Ah9tscXa4lns5h3FvqEaY6bduYl7xQwO7LGGVaaYFmj4kMLn1Fyd+gw8vdRBd4NC7VCRJ2NxshMHdKwW4sS5YK+MT+s/3yAXlkhj9vXPczJAXBVNjn3jX4CWQIDAQAB";
+        private static readonly List<string> LiveCertificatePublicKeys = new List<string>
+        {
+            // Public key for gw1.judopay.com
+            "MIIBCgKCAQEAqyx7Fg8FkI7Q2yaai//AXURuithFkoPfBliXOpGQ8O8vo+foXTLVpWmStnCUfzhm5dIJEgKn/FVK+/M5vGQSJ+aqhAL6A9Eq+UazOY2X65QweOQiQmcC6WELYBO+wx8oXQLp/PVYLlAfaljFRBqo3c4kfeLwd4VISJuFs941B7vTrkgZ0t6TSbnwUZNpSLr53pNyR4QJ/OSPsoxtdec7z+38dPUW0Ah9tscXa4lns5h3FvqEaY6bduYl7xQwO7LGGVaaYFmj4kMLn1Fyd+gw8vdRBd4NC7VCRJ2NxshMHdKwW4sS5YK+MT+s/3yAXlkhj9vXPczJAXBVNjn3jX4CWQIDAQAB",
+            // Fallback public key for gw1.judopay.com
+            "MIIBCAKCAQEAn5miKk6Db6bAofUTUU4BMfbQ5YL8OqzwVxbTqsbebECh+NdkB1v38+2yLll3brjF1fGPqgHYHmKO90ZLrgOh/CYAnhNH472v4+UAr0xFTQUEcZe0oTjI5wvRBnQeOZk182n5DaZvyOoOdDhZ6l8nfrAX58fO2DmRduQ0+GFBSrnh6dbzc4Z9XmmomLR6YOVF9AFe4ns0lP7uEW0wdh7p5sGRXqwQXhpfXHS+gZkgp4zPgpD7iHtaO+DlzJTMBZKDF8jVaGeFYO2Tj4s244TbeM8dClSr8oosAsu+5t5zXgZYrn0XkcQv2kyjnZ3wfs9j2OKbTzj1xNw8JSf7MOcnIwIBJQ==",
+            // Public key for *.judopay.com
+            "MIIBCgKCAQEAqyx7Fg8FkI7Q2yaai//AXURuithFkoPfBliXOpGQ8O8vo+foXTLVpWmStnCUfzhm5dIJEgKn/FVK+/M5vGQSJ+aqhAL6A9Eq+UazOY2X65QweOQiQmcC6WELYBO+wx8oXQLp/PVYLlAfaljFRBqo3c4kfeLwd4VISJuFs941B7vTrkgZ0t6TSbnwUZNpSLr53pNyR4QJ/OSPsoxtdec7z+38dPUW0Ah9tscXa4lns5h3FvqEaY6bduYl7xQwO7LGGVaaYFmj4kMLn1Fyd+gw8vdRBd4NC7VCRJ2NxshMHdKwW4sS5YK+MT+s/3yAXlkhj9vXPczJAXBVNjn3jX4CWQIDAQAB"
+        };
 
-        private const string SandboxCertificatePublicKey = "MIIBCgKCAQEAmMrGJkxm/vvfZ/IU0EuhljWlgxzdRnkgWzkzB1NGpOoZw1AJWYq3Lg1uOvphltQ+oq3athGIhoXYuQrOh7BsMpw2vXj1VTwGP9/1AkNOXXCzTVKATw+AwuBwdIYg0yOqTB4wImvLqDVFuuO6f0SnFZ3ntqlNFvOBzxGHKlr6Y20fsiXzv95vRfkwtb5exNUy9bnKn81GyPONWVeLgqFEM7TQO7eUbLEMcnEwgPCvMhYKggSN/i99wqcMomEBlfsfFxcYG7R6P8GmiXBkHKaPO2JXf4OMOMcLOmG7kyRZYBPWNTlQsUsgatTUTO1oFJuMYRIcUE+G51C2FLraCH2YqQIDAQAB";
+        private static readonly List<string> SandboxCertificatePublicKeys = new List<string>
+        {
+            // Public key for *.judopay-sandbox.com used by gw1.judopay-sandbox.com 
+            "MIIBCgKCAQEAmMrGJkxm/vvfZ/IU0EuhljWlgxzdRnkgWzkzB1NGpOoZw1AJWYq3Lg1uOvphltQ+oq3athGIhoXYuQrOh7BsMpw2vXj1VTwGP9/1AkNOXXCzTVKATw+AwuBwdIYg0yOqTB4wImvLqDVFuuO6f0SnFZ3ntqlNFvOBzxGHKlr6Y20fsiXzv95vRfkwtb5exNUy9bnKn81GyPONWVeLgqFEM7TQO7eUbLEMcnEwgPCvMhYKggSN/i99wqcMomEBlfsfFxcYG7R6P8GmiXBkHKaPO2JXf4OMOMcLOmG7kyRZYBPWNTlQsUsgatTUTO1oFJuMYRIcUE+G51C2FLraCH2YqQIDAQAB",
+            // Public key for *.judopay.com
+            "MIIBCgKCAQEAqyx7Fg8FkI7Q2yaai//AXURuithFkoPfBliXOpGQ8O8vo+foXTLVpWmStnCUfzhm5dIJEgKn/FVK+/M5vGQSJ+aqhAL6A9Eq+UazOY2X65QweOQiQmcC6WELYBO+wx8oXQLp/PVYLlAfaljFRBqo3c4kfeLwd4VISJuFs941B7vTrkgZ0t6TSbnwUZNpSLr53pNyR4QJ/OSPsoxtdec7z+38dPUW0Ah9tscXa4lns5h3FvqEaY6bduYl7xQwO7LGGVaaYFmj4kMLn1Fyd+gw8vdRBd4NC7VCRJ2NxshMHdKwW4sS5YK+MT+s/3yAXlkhj9vXPczJAXBVNjn3jX4CWQIDAQAB"
+        };
 
         static JudoPaymentsFactory()
         {
-            ServicePointManager.ServerCertificateValidationCallback += PinPublicKey;
+            ServicePointManager.ServerCertificateValidationCallback = PinPublicKey;
         }
 
         /// <summary>
@@ -89,46 +103,44 @@ namespace JudoPayDotNet
             switch (judoEnvironment)
             {
                 case JudoEnvironment.Sandbox:
-                    defaultValue = DEFAULT_SANDBOX_URL;
+                    defaultValue = DefaultSandboxUrl;
                     break;
                 case JudoEnvironment.Live:
-                    defaultValue = DEFAULT_LIVE_URL;
+                    defaultValue = DefaultLiveUrl;
                     break;
             }
 
             return defaultValue;
         }
 
-        private static bool PinPublicKey(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+        internal static bool PinPublicKey(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
         {
             if (null == certificate)
                 return false;
 
-            var webRequest = sender as HttpWebRequest;
-            if (webRequest != null)
+            if (sender is HttpWebRequest webRequest)
             {
-                // If we're connecting to the live system vault
-                if (webRequest.Address.ToString().StartsWith(DEFAULT_LIVE_URL, StringComparison.InvariantCultureIgnoreCase))
+                // If we're connecting to the live environment
+                if (webRequest.Address.ToString().StartsWith(DefaultLiveUrl, StringComparison.InvariantCultureIgnoreCase))
                 {
                     var serviceKey = Convert.ToBase64String(certificate.GetPublicKey());
 
                     // If the certifcate public key doesn't match fail the validation
-                    if (serviceKey != LiveCertificatePublicKey)
+                    if (!LiveCertificatePublicKeys.Contains(serviceKey))
                         return false;
                 }
-
-                // If we're connecting to the live system vault
-                if (webRequest.Address.ToString().StartsWith(DEFAULT_SANDBOX_URL, StringComparison.InvariantCultureIgnoreCase))
+                // If we're connecting to the sandbox environment
+                else if (webRequest.Address.ToString().StartsWith(DefaultSandboxUrl, StringComparison.InvariantCultureIgnoreCase))
                 {
                     var serviceKey = Convert.ToBase64String(certificate.GetPublicKey());
 
-                    // If the certifcate public key doesn't match fail the validation
-                    if (serviceKey != SandboxCertificatePublicKey)
+                    // If the certificate public key doesn't match fail the validation
+                    if (!SandboxCertificatePublicKeys.Contains(serviceKey))
                         return false;
                 }
             }
 
-            // Propogate any previous errors
+            // Propagate any previous errors
             return sslPolicyErrors == SslPolicyErrors.None;
         }
 

--- a/JudoPayDotNet/JudoPaymentsFactory.cs
+++ b/JudoPayDotNet/JudoPaymentsFactory.cs
@@ -126,7 +126,7 @@ namespace JudoPayDotNet
             {
                 var serviceKey = Convert.ToBase64String(certificate.GetPublicKey());
                 var publicKeys = GetPublicKeys(webRequest.Address.ToString());
-                if (!publicKeys.Contains(serviceKey))
+                if (publicKeys.Count > 0 && !publicKeys.Contains(serviceKey))
                     return false;
             }
 

--- a/JudoPayDotNet/JudoPaymentsFactory.cs
+++ b/JudoPayDotNet/JudoPaymentsFactory.cs
@@ -18,28 +18,32 @@ namespace JudoPayDotNet
     /// </summary>
     public static class JudoPaymentsFactory
     {
-        // Future state will use https://api-sandbox.judopay.com/ with *.judopay.com certificate
-        private const string DefaultSandboxUrl = "https://gw1.judopay-sandbox.com/";
+        private const string DefaultSandboxUrl = "https://api-sandbox.judopay.com/"; // Uses *.judopay.com certificate
+        private const string LegacySandboxUrl = "https://gw1.judopay-sandbox.com/"; // Uses *.judopay-sandbox.com certificate
 
-        // Future state will use https://api.judopay.com/ with *.judopay.com certificate
-        private const string DefaultLiveUrl = "https://gw1.judopay.com/";
-        
-        private static readonly List<string> LiveCertificatePublicKeys = new List<string>
+        private const string DefaultLiveUrl = "https://api.judopay.com/"; // Uses *.judopay.com certificate
+        private const string LegacyLiveUrl = "https://gw1.judopay.com/"; // Uses gw1.judopay.com certificate
+
+        private static readonly List<string> ApiCertificatePublicKeys = new List<string>
+        {
+            // Public key for *.judopay.com
+            "MIIBCgKCAQEAqyx7Fg8FkI7Q2yaai//AXURuithFkoPfBliXOpGQ8O8vo+foXTLVpWmStnCUfzhm5dIJEgKn/FVK+/M5vGQSJ+aqhAL6A9Eq+UazOY2X65QweOQiQmcC6WELYBO+wx8oXQLp/PVYLlAfaljFRBqo3c4kfeLwd4VISJuFs941B7vTrkgZ0t6TSbnwUZNpSLr53pNyR4QJ/OSPsoxtdec7z+38dPUW0Ah9tscXa4lns5h3FvqEaY6bduYl7xQwO7LGGVaaYFmj4kMLn1Fyd+gw8vdRBd4NC7VCRJ2NxshMHdKwW4sS5YK+MT+s/3yAXlkhj9vXPczJAXBVNjn3jX4CWQIDAQAB",
+            // Fallback public key for *.judopay.com
+            "TBD"
+        };
+
+        private static readonly List<string> LegacyLiveCertificatePublicKeys = new List<string>
         {
             // Public key for gw1.judopay.com
             "MIIBCgKCAQEAqyx7Fg8FkI7Q2yaai//AXURuithFkoPfBliXOpGQ8O8vo+foXTLVpWmStnCUfzhm5dIJEgKn/FVK+/M5vGQSJ+aqhAL6A9Eq+UazOY2X65QweOQiQmcC6WELYBO+wx8oXQLp/PVYLlAfaljFRBqo3c4kfeLwd4VISJuFs941B7vTrkgZ0t6TSbnwUZNpSLr53pNyR4QJ/OSPsoxtdec7z+38dPUW0Ah9tscXa4lns5h3FvqEaY6bduYl7xQwO7LGGVaaYFmj4kMLn1Fyd+gw8vdRBd4NC7VCRJ2NxshMHdKwW4sS5YK+MT+s/3yAXlkhj9vXPczJAXBVNjn3jX4CWQIDAQAB",
             // Fallback public key for gw1.judopay.com
-            "MIIBCAKCAQEAn5miKk6Db6bAofUTUU4BMfbQ5YL8OqzwVxbTqsbebECh+NdkB1v38+2yLll3brjF1fGPqgHYHmKO90ZLrgOh/CYAnhNH472v4+UAr0xFTQUEcZe0oTjI5wvRBnQeOZk182n5DaZvyOoOdDhZ6l8nfrAX58fO2DmRduQ0+GFBSrnh6dbzc4Z9XmmomLR6YOVF9AFe4ns0lP7uEW0wdh7p5sGRXqwQXhpfXHS+gZkgp4zPgpD7iHtaO+DlzJTMBZKDF8jVaGeFYO2Tj4s244TbeM8dClSr8oosAsu+5t5zXgZYrn0XkcQv2kyjnZ3wfs9j2OKbTzj1xNw8JSf7MOcnIwIBJQ==",
-            // Public key for *.judopay.com
-            "MIIBCgKCAQEAqyx7Fg8FkI7Q2yaai//AXURuithFkoPfBliXOpGQ8O8vo+foXTLVpWmStnCUfzhm5dIJEgKn/FVK+/M5vGQSJ+aqhAL6A9Eq+UazOY2X65QweOQiQmcC6WELYBO+wx8oXQLp/PVYLlAfaljFRBqo3c4kfeLwd4VISJuFs941B7vTrkgZ0t6TSbnwUZNpSLr53pNyR4QJ/OSPsoxtdec7z+38dPUW0Ah9tscXa4lns5h3FvqEaY6bduYl7xQwO7LGGVaaYFmj4kMLn1Fyd+gw8vdRBd4NC7VCRJ2NxshMHdKwW4sS5YK+MT+s/3yAXlkhj9vXPczJAXBVNjn3jX4CWQIDAQAB"
+            "MIIBCAKCAQEAn5miKk6Db6bAofUTUU4BMfbQ5YL8OqzwVxbTqsbebECh+NdkB1v38+2yLll3brjF1fGPqgHYHmKO90ZLrgOh/CYAnhNH472v4+UAr0xFTQUEcZe0oTjI5wvRBnQeOZk182n5DaZvyOoOdDhZ6l8nfrAX58fO2DmRduQ0+GFBSrnh6dbzc4Z9XmmomLR6YOVF9AFe4ns0lP7uEW0wdh7p5sGRXqwQXhpfXHS+gZkgp4zPgpD7iHtaO+DlzJTMBZKDF8jVaGeFYO2Tj4s244TbeM8dClSr8oosAsu+5t5zXgZYrn0XkcQv2kyjnZ3wfs9j2OKbTzj1xNw8JSf7MOcnIwIBJQ=="
         };
 
-        private static readonly List<string> SandboxCertificatePublicKeys = new List<string>
+        private static readonly List<string> LegacySandboxCertificatePublicKeys = new List<string>
         {
             // Public key for *.judopay-sandbox.com used by gw1.judopay-sandbox.com 
-            "MIIBCgKCAQEAmMrGJkxm/vvfZ/IU0EuhljWlgxzdRnkgWzkzB1NGpOoZw1AJWYq3Lg1uOvphltQ+oq3athGIhoXYuQrOh7BsMpw2vXj1VTwGP9/1AkNOXXCzTVKATw+AwuBwdIYg0yOqTB4wImvLqDVFuuO6f0SnFZ3ntqlNFvOBzxGHKlr6Y20fsiXzv95vRfkwtb5exNUy9bnKn81GyPONWVeLgqFEM7TQO7eUbLEMcnEwgPCvMhYKggSN/i99wqcMomEBlfsfFxcYG7R6P8GmiXBkHKaPO2JXf4OMOMcLOmG7kyRZYBPWNTlQsUsgatTUTO1oFJuMYRIcUE+G51C2FLraCH2YqQIDAQAB",
-            // Public key for *.judopay.com
-            "MIIBCgKCAQEAqyx7Fg8FkI7Q2yaai//AXURuithFkoPfBliXOpGQ8O8vo+foXTLVpWmStnCUfzhm5dIJEgKn/FVK+/M5vGQSJ+aqhAL6A9Eq+UazOY2X65QweOQiQmcC6WELYBO+wx8oXQLp/PVYLlAfaljFRBqo3c4kfeLwd4VISJuFs941B7vTrkgZ0t6TSbnwUZNpSLr53pNyR4QJ/OSPsoxtdec7z+38dPUW0Ah9tscXa4lns5h3FvqEaY6bduYl7xQwO7LGGVaaYFmj4kMLn1Fyd+gw8vdRBd4NC7VCRJ2NxshMHdKwW4sS5YK+MT+s/3yAXlkhj9vXPczJAXBVNjn3jX4CWQIDAQAB"
+            "MIIBCgKCAQEAmMrGJkxm/vvfZ/IU0EuhljWlgxzdRnkgWzkzB1NGpOoZw1AJWYq3Lg1uOvphltQ+oq3athGIhoXYuQrOh7BsMpw2vXj1VTwGP9/1AkNOXXCzTVKATw+AwuBwdIYg0yOqTB4wImvLqDVFuuO6f0SnFZ3ntqlNFvOBzxGHKlr6Y20fsiXzv95vRfkwtb5exNUy9bnKn81GyPONWVeLgqFEM7TQO7eUbLEMcnEwgPCvMhYKggSN/i99wqcMomEBlfsfFxcYG7R6P8GmiXBkHKaPO2JXf4OMOMcLOmG7kyRZYBPWNTlQsUsgatTUTO1oFJuMYRIcUE+G51C2FLraCH2YqQIDAQAB"
         };
 
         static JudoPaymentsFactory()
@@ -113,70 +117,81 @@ namespace JudoPayDotNet
             return defaultValue;
         }
 
-        internal static bool PinPublicKey(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+        private static bool PinPublicKey(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
         {
             if (null == certificate)
                 return false;
 
             if (sender is HttpWebRequest webRequest)
             {
-                // If we're connecting to the live environment
-                if (webRequest.Address.ToString().StartsWith(DefaultLiveUrl, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    var serviceKey = Convert.ToBase64String(certificate.GetPublicKey());
-
-                    // If the certifcate public key doesn't match fail the validation
-                    if (!LiveCertificatePublicKeys.Contains(serviceKey))
-                        return false;
-                }
-                // If we're connecting to the sandbox environment
-                else if (webRequest.Address.ToString().StartsWith(DefaultSandboxUrl, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    var serviceKey = Convert.ToBase64String(certificate.GetPublicKey());
-
-                    // If the certificate public key doesn't match fail the validation
-                    if (!SandboxCertificatePublicKeys.Contains(serviceKey))
-                        return false;
-                }
+                var serviceKey = Convert.ToBase64String(certificate.GetPublicKey());
+                var publicKeys = GetPublicKeys(webRequest.Address.ToString());
+                if (!publicKeys.Contains(serviceKey))
+                    return false;
             }
 
             // Propagate any previous errors
             return sslPolicyErrors == SslPolicyErrors.None;
         }
 
+        private static List<string> GetPublicKeys(string baseUrl)
+        {
+            var publicKeys = new List<string>();
+            if (baseUrl.StartsWith(DefaultLiveUrl, StringComparison.InvariantCultureIgnoreCase) ||
+                baseUrl.StartsWith(DefaultSandboxUrl, StringComparison.InvariantCultureIgnoreCase))
+            {
+                // Default api.judopay.com and api-sandbox.judopay.com Urls use *.judopay.com certificate
+                publicKeys = ApiCertificatePublicKeys;
+            }
+            else if (baseUrl.StartsWith(LegacyLiveUrl, StringComparison.InvariantCultureIgnoreCase))
+            {
+                // Legacy live Url uses gw1.judopay.com certificate - keep supporting for now as merchants
+                // may still specify the LegacyLiveUrl using the Create method with baseUrl parameter
+                publicKeys = LegacyLiveCertificatePublicKeys;
+            }
+            else if (baseUrl.StartsWith(LegacySandboxUrl, StringComparison.InvariantCultureIgnoreCase))
+            {
+                // Legacy sandbox Url uses *.judopay-sandbox.com certificate - keep supporting for now as
+                // merchants may still specify the LegacySandboxUrl using the Create method with baseUrl parameter
+                publicKeys = LegacySandboxCertificatePublicKeys;
+            }
+            return publicKeys;
+        }
+
         /// <summary>
-        /// Creates an instance of the judopay api client with a custom base url, that will authenticate with your api token and secret.
+        /// Creates an instance of the Judopay API client against a specified environment, that will authenticate with your api token and secret.
         /// </summary>
-        /// <param name="judoEnvironment">Either the sandbox (development/testing) or live environments</param>
+        /// <param name="judoEnvironment">Either the Sandbox (development/testing) or Live environments</param>
         /// <param name="token">Your API token (from our merchant dashboard)</param>
         /// <param name="secret">Your API secret (from our merchant dashboard)</param>
-        /// <returns>Initialized instance of the Judopay api client</returns>
+        /// <returns>Initialized instance of the Judopay API client</returns>
         public static JudoPayApi Create(JudoEnvironment judoEnvironment, string token, string secret)
         {
             return Create(token, secret, GetEnvironmentUrl(judoEnvironment));
         }
 
         /// <summary>
-        /// Creates an instance of the judopay api client with a custom base url, that will authenticate with your api token and secret.
+        /// Creates an instance of the Judopay API client against a specified environment using a custom userAgent,
+        /// that will authenticate with your api token and secret.
         /// </summary>
-        /// <param name="judoEnvironment">Either the sandbox (development/testing) or live environments</param>
+        /// <param name="judoEnvironment">Either the Sandbox (development/testing) or Live environments</param>
         /// <param name="token">Your API token (from our merchant dashboard)</param>
         /// <param name="secret">Your API secret (from our merchant dashboard)</param>
         /// <param name="userAgent">The name and version number of the calling application, should be in the form PRODUCT/VERSION</param>
-        /// <returns>Initialized instance of the Judopay api client</returns>
+        /// <returns>Initialized instance of the Judopay API client</returns>
         public static JudoPayApi Create(JudoEnvironment judoEnvironment, string token, string secret, ProductInfoHeaderValue userAgent)
         {
             return Create(new Credentials(token, secret), GetEnvironmentUrl(judoEnvironment), userAgent);
         }
 
         /// <summary>
-        /// Creates an instance of the judopay API client with a custom base url, that will authenticate with your API token and secret.
+        /// Creates an instance of the Judopay API client with a custom base url, that will authenticate with your API token and secret.
         /// </summary>
         /// <remarks>This is intended for development/sandbox environments</remarks>
         /// <param name="token">Your API token (from our merchant dashboard)</param>
         /// <param name="secret">Your API secret (from our merchant dashboard)</param>
-        /// <param name="baseUrl">Base URL for the Judopay api</param>
-        /// <returns>Initialized instance of the Judopay api client</returns>
+        /// <param name="baseUrl">Base URL for the Judopay API</param>
+        /// <returns>Initialized instance of the Judopay API client</returns>
         public static JudoPayApi Create(string token, string secret, string baseUrl)
         {
             var credentials = new Credentials(token, secret);

--- a/JudoPayDotNet/JudoPaymentsFactory.cs
+++ b/JudoPayDotNet/JudoPaymentsFactory.cs
@@ -26,24 +26,18 @@ namespace JudoPayDotNet
 
         private static readonly List<string> ApiCertificatePublicKeys = new List<string>
         {
-            // Public key for *.judopay.com
+            // Public key for *.judopay.com (also used for gw1.judopay.com)
             "MIIBCgKCAQEAqyx7Fg8FkI7Q2yaai//AXURuithFkoPfBliXOpGQ8O8vo+foXTLVpWmStnCUfzhm5dIJEgKn/FVK+/M5vGQSJ+aqhAL6A9Eq+UazOY2X65QweOQiQmcC6WELYBO+wx8oXQLp/PVYLlAfaljFRBqo3c4kfeLwd4VISJuFs941B7vTrkgZ0t6TSbnwUZNpSLr53pNyR4QJ/OSPsoxtdec7z+38dPUW0Ah9tscXa4lns5h3FvqEaY6bduYl7xQwO7LGGVaaYFmj4kMLn1Fyd+gw8vdRBd4NC7VCRJ2NxshMHdKwW4sS5YK+MT+s/3yAXlkhj9vXPczJAXBVNjn3jX4CWQIDAQAB",
-            // Fallback public key for *.judopay.com
-            "TBD"
-        };
-
-        private static readonly List<string> LegacyLiveCertificatePublicKeys = new List<string>
-        {
-            // Public key for gw1.judopay.com
-            "MIIBCgKCAQEAqyx7Fg8FkI7Q2yaai//AXURuithFkoPfBliXOpGQ8O8vo+foXTLVpWmStnCUfzhm5dIJEgKn/FVK+/M5vGQSJ+aqhAL6A9Eq+UazOY2X65QweOQiQmcC6WELYBO+wx8oXQLp/PVYLlAfaljFRBqo3c4kfeLwd4VISJuFs941B7vTrkgZ0t6TSbnwUZNpSLr53pNyR4QJ/OSPsoxtdec7z+38dPUW0Ah9tscXa4lns5h3FvqEaY6bduYl7xQwO7LGGVaaYFmj4kMLn1Fyd+gw8vdRBd4NC7VCRJ2NxshMHdKwW4sS5YK+MT+s/3yAXlkhj9vXPczJAXBVNjn3jX4CWQIDAQAB",
-            // Fallback public key for gw1.judopay.com
+            // Fallback public key for *.judopay.com (also used for gw1.judopay.com)
             "MIIBCAKCAQEAn5miKk6Db6bAofUTUU4BMfbQ5YL8OqzwVxbTqsbebECh+NdkB1v38+2yLll3brjF1fGPqgHYHmKO90ZLrgOh/CYAnhNH472v4+UAr0xFTQUEcZe0oTjI5wvRBnQeOZk182n5DaZvyOoOdDhZ6l8nfrAX58fO2DmRduQ0+GFBSrnh6dbzc4Z9XmmomLR6YOVF9AFe4ns0lP7uEW0wdh7p5sGRXqwQXhpfXHS+gZkgp4zPgpD7iHtaO+DlzJTMBZKDF8jVaGeFYO2Tj4s244TbeM8dClSr8oosAsu+5t5zXgZYrn0XkcQv2kyjnZ3wfs9j2OKbTzj1xNw8JSf7MOcnIwIBJQ=="
         };
 
         private static readonly List<string> LegacySandboxCertificatePublicKeys = new List<string>
         {
-            // Public key for *.judopay-sandbox.com used by gw1.judopay-sandbox.com 
-            "MIIBCgKCAQEAmMrGJkxm/vvfZ/IU0EuhljWlgxzdRnkgWzkzB1NGpOoZw1AJWYq3Lg1uOvphltQ+oq3athGIhoXYuQrOh7BsMpw2vXj1VTwGP9/1AkNOXXCzTVKATw+AwuBwdIYg0yOqTB4wImvLqDVFuuO6f0SnFZ3ntqlNFvOBzxGHKlr6Y20fsiXzv95vRfkwtb5exNUy9bnKn81GyPONWVeLgqFEM7TQO7eUbLEMcnEwgPCvMhYKggSN/i99wqcMomEBlfsfFxcYG7R6P8GmiXBkHKaPO2JXf4OMOMcLOmG7kyRZYBPWNTlQsUsgatTUTO1oFJuMYRIcUE+G51C2FLraCH2YqQIDAQAB"
+            // Public key for *.judopay-sandbox.com used by gw1.judopay-sandbox.com
+            "MIIBCgKCAQEAmMrGJkxm/vvfZ/IU0EuhljWlgxzdRnkgWzkzB1NGpOoZw1AJWYq3Lg1uOvphltQ+oq3athGIhoXYuQrOh7BsMpw2vXj1VTwGP9/1AkNOXXCzTVKATw+AwuBwdIYg0yOqTB4wImvLqDVFuuO6f0SnFZ3ntqlNFvOBzxGHKlr6Y20fsiXzv95vRfkwtb5exNUy9bnKn81GyPONWVeLgqFEM7TQO7eUbLEMcnEwgPCvMhYKggSN/i99wqcMomEBlfsfFxcYG7R6P8GmiXBkHKaPO2JXf4OMOMcLOmG7kyRZYBPWNTlQsUsgatTUTO1oFJuMYRIcUE+G51C2FLraCH2YqQIDAQAB",
+            // Fallback public key for *.judopay-sandbox.com used by gw1.judopay-sandbox.com
+            "MIIBCAKCAQEA4J29vB5RqkGKubPT4wjTn8Ww8StXSOAIP36d0YantOb03X1aiC/+WZQo3/z1D3H1anGn7gqJicdMNAJPC+JIpI2ov1cbCjSN+6Gm5j0+igi8Q8MWY/IdCPQjOVxdQb6P8wEaImieQQdJEeHZlSt3hVb+dIi9EhMX182GfSjXVhv1lnCjxvFYcZviMNF3zA6DcjBsLxoKWU0AbHF8VXvemp15WV+jAq0IeTTzr97vE+hGEeGIZfWqamms4nSTYXUlnFD3NgqhBmzBeBorr/MzWhUz5+qdmZYGcbUjNwKovZvR/TXGIwz9mE2IWjrbxhQllH5VDo2iHT5gLMUSCkefjwIBJQ=="
         };
 
         static JudoPaymentsFactory()
@@ -138,16 +132,12 @@ namespace JudoPayDotNet
         {
             var publicKeys = new List<string>();
             if (baseUrl.StartsWith(DefaultLiveUrl, StringComparison.InvariantCultureIgnoreCase) ||
-                baseUrl.StartsWith(DefaultSandboxUrl, StringComparison.InvariantCultureIgnoreCase))
+                baseUrl.StartsWith(DefaultSandboxUrl, StringComparison.InvariantCultureIgnoreCase) ||
+                baseUrl.StartsWith(LegacyLiveUrl, StringComparison.InvariantCultureIgnoreCase))
             {
                 // Default api.judopay.com and api-sandbox.judopay.com Urls use *.judopay.com certificate
+                // Legacy live gw1.judopay.com certificate uses same public key as *.judopay.com certficate
                 publicKeys = ApiCertificatePublicKeys;
-            }
-            else if (baseUrl.StartsWith(LegacyLiveUrl, StringComparison.InvariantCultureIgnoreCase))
-            {
-                // Legacy live Url uses gw1.judopay.com certificate - keep supporting for now as merchants
-                // may still specify the LegacyLiveUrl using the Create method with baseUrl parameter
-                publicKeys = LegacyLiveCertificatePublicKeys;
             }
             else if (baseUrl.StartsWith(LegacySandboxUrl, StringComparison.InvariantCultureIgnoreCase))
             {

--- a/JudoPayDotNetIntegrationTests/IntegrationTestsBase.cs
+++ b/JudoPayDotNetIntegrationTests/IntegrationTestsBase.cs
@@ -302,7 +302,7 @@ namespace JudoPayDotNetIntegrationTests
                 ClientIpAddress = "127.0.0.1",
                 CompanyName = "Test",
                 Currency = "GBP",
-                ExpiryDate = DateTimeOffset.Now,
+                ExpiryDate = DateTimeOffset.Now.AddMinutes(5),
                 JudoId = Configuration.Judoid,
                 PartnerServiceFee = 10,
                 PaymentCancelUrl = "http://test.com",

--- a/JudoPayDotNetSampleApp/App.config
+++ b/JudoPayDotNetSampleApp/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/JudoPayDotNetSampleApp/JudoPayDotNetFrameworkSampleApp.cs
+++ b/JudoPayDotNetSampleApp/JudoPayDotNetFrameworkSampleApp.cs
@@ -5,15 +5,13 @@ using JudoPayDotNet.Models;
 
 namespace JudoPayDotNetSampleApp
 {
-    class Program
+    class JudoPayDotNetFrameworkSampleApp
     {
         private static string ApiToken = "Izx9omsBR15LatAl";
         private static readonly string ApiSecret = "b5787124845533d8e68d12a586fa3713871b876b528600ebfdc037afec880cd6";
 
         static void Main(string[] args)
         {
-            Console.WriteLine("Starting CardPayment call");
-
             var client = JudoPaymentsFactory.Create(JudoPayDotNet.Enums.JudoEnvironment.Sandbox, ApiToken, ApiSecret);
             var cardPaymentModel = new CardPaymentModel
             {
@@ -34,22 +32,30 @@ namespace JudoPayDotNetSampleApp
 
             client.Payments.Create(cardPaymentModel).ContinueWith(result =>
             {
-                var paymentResult = result.Result;
-
-                if (!paymentResult.HasError && paymentResult.Response.Result == "Success")
+                if (result.IsFaulted)
                 {
-                    Console.WriteLine($"Payment successful. Transaction Reference {paymentResult.Response.ReceiptId}");
+                    Console.WriteLine($"Payment request failed, exception={result.Exception.InnerExceptions[0].Message}");
                 }
                 else
                 {
-                    Console.WriteLine("Payment failed");
+                    var paymentResult = result.Result;
+
+                    if (!paymentResult.HasError && paymentResult.Response.Result == "Success")
+                    {
+                        Console.WriteLine($"Payment successful. Transaction Reference {paymentResult.Response.ReceiptId}");
+                    }
+                    else
+                    {
+                        Console.WriteLine("Payment failed");
+                    }
                 }
-                Console.WriteLine("Finished!");
-
             });
+            Console.WriteLine("Payment request sent");
+            Thread.Sleep(2000);
 
-            Thread.Sleep(5000);
+            // Wait for the user to respond before closing.
+            Console.WriteLine("Press any key to close the app...");
+            Console.ReadKey();
         }
-
     }
 }

--- a/JudoPayDotNetSampleApp/JudoPayDotNetSampleApp.csproj
+++ b/JudoPayDotNetSampleApp/JudoPayDotNetSampleApp.csproj
@@ -43,7 +43,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Program.cs" />
+    <Compile Include="JudoPayDotNetFrameworkSampleApp.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/JudoPayDotNetSampleApp/JudoPayDotNetSampleApp.csproj
+++ b/JudoPayDotNetSampleApp/JudoPayDotNetSampleApp.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{69122E3D-120B-43CD-A710-5091792CF323}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>JudoPayDotNetSampleApp</RootNamespace>
+    <AssemblyName>JudoPayDotNetSampleApp</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\JudoPayDotNet\JudoPayDotNet.csproj">
+      <Project>{365d3fe1-5aa7-4c99-8aef-0d780c28e842}</Project>
+      <Name>JudoPayDotNet</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/JudoPayDotNetSampleApp/Program.cs
+++ b/JudoPayDotNetSampleApp/Program.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Threading;
+using JudoPayDotNet;
+using JudoPayDotNet.Models;
+
+namespace JudoPayDotNetSampleApp
+{
+    class Program
+    {
+        private static string ApiToken = "Izx9omsBR15LatAl";
+        private static readonly string ApiSecret = "b5787124845533d8e68d12a586fa3713871b876b528600ebfdc037afec880cd6";
+
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Starting CardPayment call");
+
+            var client = JudoPaymentsFactory.Create(JudoPayDotNet.Enums.JudoEnvironment.Sandbox, ApiToken, ApiSecret);
+            var cardPaymentModel = new CardPaymentModel
+            {
+                JudoId = "100915867",
+
+                // value of the payment
+                Amount = 1.01m,
+                Currency = "GBP",
+
+                // card details
+                CardNumber = "4976000000003436",
+                ExpiryDate = "1220",
+                CV2 = "452",
+
+                // an identifier for your customer
+                YourConsumerReference = "MyCustomer004",
+            };
+
+            client.Payments.Create(cardPaymentModel).ContinueWith(result =>
+            {
+                var paymentResult = result.Result;
+
+                if (!paymentResult.HasError && paymentResult.Response.Result == "Success")
+                {
+                    Console.WriteLine($"Payment successful. Transaction Reference {paymentResult.Response.ReceiptId}");
+                }
+                else
+                {
+                    Console.WriteLine("Payment failed");
+                }
+                Console.WriteLine("Finished!");
+
+            });
+
+            Thread.Sleep(5000);
+        }
+
+    }
+}

--- a/JudoPayDotNetSampleApp/Properties/AssemblyInfo.cs
+++ b/JudoPayDotNetSampleApp/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("JudoPayDotNetSampleApp")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("JudoPayDotNetSampleApp")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("69122e3d-120b-43cd-a710-5091792cf323")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/JudoPayDotNetTests/Configuration/JudoSettingsTests.cs
+++ b/JudoPayDotNetTests/Configuration/JudoSettingsTests.cs
@@ -8,8 +8,8 @@ namespace JudoPayDotNetTests.Configuration
     public class JudoSettingsTests
     {
         [Test]
-        [TestCase(JudoEnvironment.Sandbox, "https://gw1.judopay-sandbox.com/")]
-        [TestCase(JudoEnvironment.Live, "https://gw1.judopay.com/")]
+        [TestCase(JudoEnvironment.Sandbox, "https://api-sandbox.judopay.com/")]
+        [TestCase(JudoEnvironment.Live, "https://api.judopay.com/")]
 
         public void GetEnvironmentUrl(JudoEnvironment judoEnvironment, string expectedUrl)
         {

--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,7 @@ Install-Package JudoPay.Net
 You configure you Judopay API client when invoking the JudoPaymentsFactory.Create method. This has
 three parameters; environment (Sandbox for development and testing, and Live for production), and api
 token and secret. You set you API token and secret up through our [management dashboard](https://portal.judopay.com)
-after creating an account. You can create a testing account by clicking "Getting Started" in our [documentation](https://www.judopay.com/docs)
+after creating an account. You can create a testing account by clicking "Getting Started" in our [documentation](https://docs.judopay.com/en/introduction/getting-started-with-judopay.html)
 
 ```c#
 var client = JudoPaymentsFactory.Create(JudoPayDotNet.Enums.JudoEnvironment.Sandbox, "<TOKEN>", "<SECRET>");

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.1.{build}
+version: 3.0.{build}
 image: Visual Studio 2017
 skip_branch_with_pr: true
 # if wanting to publish the package internally


### PR DESCRIPTION
Work in progress - needs updated with public keys for fallback URLs for *.judopay-sandbox.com (if available), and *.judopay.com

The certs for the legacy URLs https://gw1.judopay.com and https://gw1.judopay-sandbox.com are still checked as those URLs could be specified by merchants using the Create method that takes a baseUrl parameter

New sample app subproject uses .Net framework so certificate checks are applied, whereas checks are not performed in the .Net Core projects for the build and integration tests

PR is to a release branch rather than master as we won't release v3.0 of this SDK until the work to support 3SD2 is included