### PR TITLE
CardAddressNoMandatoryPostCode-JR-5915

### DIFF
--- a/JudoPayDotNet/Models/CardAddressModel.cs
+++ b/JudoPayDotNet/Models/CardAddressModel.cs
@@ -10,7 +10,6 @@ namespace JudoPayDotNet.Models
     [DataContract]
     public class CardAddressModel
     {
-
         /// <summary>
         /// Gets or sets the Address1
         /// </summary>
@@ -65,17 +64,16 @@ namespace JudoPayDotNet.Models
         /// <value>
         /// The post code.
         /// </value>
-        [DataMember(IsRequired = true)]
+        [DataMember(IsRequired = false)]
         public string PostCode { get; set; }
 
         /// <summary> 
         /// The optional country code (ISO 3166-1) for this address. 
         /// </summary> 
-        /// <remarks>UK is 826</remarks> 
-// ReSharper disable UnusedMember.Local
+        /// <remarks>UK is 826</remarks>
         [DataMember(IsRequired = false)]
         public int? CountryCode { get; set; }
-// ReSharper restore UnusedMember.Local
+
     }
     // ReSharper restore UnusedAutoPropertyAccessor.Global
 }

--- a/JudoPayDotNet/Models/EncryptedPaymentMessage.cs
+++ b/JudoPayDotNet/Models/EncryptedPaymentMessage.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Runtime.Serialization;
 
 namespace JudoPayDotNet.Models
 {
-
     /// <summary>
     /// This is the whole message from ApplePay, after decryption
     /// </summary>

--- a/JudoPayDotNet/Models/PKPaymentInnerModel.cs
+++ b/JudoPayDotNet/Models/PKPaymentInnerModel.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Runtime.Serialization;
 
 namespace JudoPayDotNet.Models
 {

--- a/JudoPayDotNet/Models/ThreeDSecureTwoPaymentModel.cs
+++ b/JudoPayDotNet/Models/ThreeDSecureTwoPaymentModel.cs
@@ -8,7 +8,7 @@ namespace JudoPayDotNet.Models
     [DataContract]
     public abstract class ThreeDSecureTwoPaymentModel : PaymentModel
     {
-        // Not explicitly assocated with 3DS2, but moved here from PaymentModel to avoid the wallet payment types inheriting it
+        // Not explicitly associated with 3DS2, but moved here from PaymentModel to avoid the wallet payment types inheriting it
         /// <summary>
         /// Gets or sets the CV2.
         /// </summary>

--- a/JudoPayDotNetIntegrationTests/IntegrationTestsBase.cs
+++ b/JudoPayDotNetIntegrationTests/IntegrationTestsBase.cs
@@ -82,6 +82,51 @@ namespace JudoPayDotNetIntegrationTests
             return ret;
         }
 
+        protected CardPaymentModel GetCardPaymentNoCardAddressModel(
+            string yourConsumerReference = null,
+            string cardNumber = "4976000000003436",
+            string cv2 = "452",
+            string cardHolderName = "John Smith",
+            bool? initialRecurringPayment = null,
+            bool? recurringPayment = null,
+            string relatedReceiptId = null,
+            RecurringPaymentType? recurringPaymentType = null,
+            string judoId = null)
+        {
+            if (string.IsNullOrEmpty(yourConsumerReference))
+            {
+                yourConsumerReference = Guid.NewGuid().ToString();
+            }
+
+            var ret = new CardPaymentModel
+            {
+                JudoId = judoId ?? Configuration.Judoid,
+                YourConsumerReference = yourConsumerReference,
+                Amount = 25,
+                CardNumber = cardNumber,
+                CV2 = cv2,
+                ExpiryDate = "12/25",
+                CardHolderName = cardHolderName,
+            };
+            if (initialRecurringPayment != null)
+            {
+                ret.InitialRecurringPayment = initialRecurringPayment;
+            }
+            if (recurringPayment != null)
+            {
+                ret.RecurringPayment = recurringPayment;
+            }
+            if (relatedReceiptId != null)
+            {
+                ret.RelatedReceiptId = relatedReceiptId;
+            }
+            if (recurringPaymentType != null)
+            {
+                ret.RecurringPaymentType = recurringPaymentType;
+            }
+            return ret;
+        }
+
         protected TokenPaymentModel GetTokenPaymentModel(
             string cardToken, 
             string yourConsumerReference = null, 

--- a/JudoPayDotNetIntegrationTests/PaymentTest.cs
+++ b/JudoPayDotNetIntegrationTests/PaymentTest.cs
@@ -358,5 +358,29 @@ namespace JudoPayDotNetIntegrationTests
             Assert.AreEqual("ThreeDSecureMpi.Cavv", firstFieldError.FieldName);
             // Other errors are the same code for the other two invalid fields
         }
+
+        [Test]
+        public async Task TestPaymentReceiptNoCardAddress()
+        {
+            // Given a payment without a card address
+            var paymentWithCardNoAddress = GetCardPaymentNoCardAddressModel();
+            var response = await JudoPayApiIridium.Payments.Create(paymentWithCardNoAddress);
+            
+            // Then the payment is successful 
+            Assert.IsNotNull(response);
+            Assert.IsFalse(response.HasError);
+            Assert.AreEqual("Success", response.Response.Result);
+
+            // When we try to retrieve the receipt 
+            var receipt = await JudoPayApiIridium.Transactions.Get(response.Response.ReceiptId);
+
+            // Then there is no error 
+            Assert.IsNotNull(receipt);
+            Assert.IsFalse(receipt.HasError);
+            Assert.AreEqual("Success", receipt.Response.Result);
+
+            // And this is the same payment receipt 
+            Assert.AreEqual(response.Response.ReceiptId, receipt.Response.ReceiptId);
+        }
     }
 }


### PR DESCRIPTION
- PostCode from CardAddressModel marked not mandatory
- Test to confirm a payment without a card address can be retrieved

**Note: the API will still reject the request if a card address object is created without a postcode** 