### PR TITLE
3dsResumeCompleteAccountDetails-JR-6385

### DIFF
--- a/JudoPayDotNet/Http/VersioningHandler.cs
+++ b/JudoPayDotNet/Http/VersioningHandler.cs
@@ -11,7 +11,7 @@ namespace JudoPayDotNet.Http
     {
         public const string API_VERSION_HEADER = "api-version";
 
-        internal const string DEFAULT_API_VERSION = "6.15";
+        internal const string DEFAULT_API_VERSION = "6.16";
 
         private readonly string _apiVersionValue;
 

--- a/JudoPayDotNet/Models/CompleteThreeDSecureTwoModel.cs
+++ b/JudoPayDotNet/Models/CompleteThreeDSecureTwoModel.cs
@@ -16,5 +16,11 @@ namespace JudoPayDotNet.Models
         /// </value>
         [DataMember(EmitDefaultValue = false)]
         public string CV2 { get; set; }
+
+        /// <summary>
+        /// Details needed for MCC 6012 transactions
+        /// </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public PrimaryAccountDetailsModel PrimaryAccountDetails { get; set; }
     }
 }

--- a/JudoPayDotNet/Models/ResumeThreeDSecureTwoModel.cs
+++ b/JudoPayDotNet/Models/ResumeThreeDSecureTwoModel.cs
@@ -21,5 +21,11 @@ namespace JudoPayDotNet.Models
 
         [DataMember(EmitDefaultValue = false)]
         public MethodCompletion MethodCompletion { get; set; }
+
+        /// <summary>
+        /// Details needed for MCC 6012 transactions
+        /// </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public PrimaryAccountDetailsModel PrimaryAccountDetails { get; set; }
     }
 }


### PR DESCRIPTION
- Default API version to 6.16
- PrimaryAccountDetails added to Resume and Complete models
- Explicit test showing how to set the object