### PR TITLE
Jr 7390 : correct case of cv2 sent to server API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ _ReSharper*/
 
 # Project specific files
 JudoPayDotNetIntegrationTests/appsettings.local.json
+
+#Nuget packages
+packages/
+!packages/repositories.config

--- a/JudoPayDotNet/JudoPayDotNet.csproj
+++ b/JudoPayDotNet/JudoPayDotNet.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <PropertyGroup Label="Package">
         <PackageId>JudoPay.Net</PackageId>
-        <Version>4.0</Version>
+        <Version>4.1</Version>
         <Authors>JudoPay</Authors>
         <Description>A .Net client for our JudoPay API, allowing you to quickly and easily process payments</Description>
         <Copyright>Copyright 2018</Copyright>

--- a/JudoPayDotNet/Models/Internal/InternalCompleteThreeDSecureTwoModel.cs
+++ b/JudoPayDotNet/Models/Internal/InternalCompleteThreeDSecureTwoModel.cs
@@ -15,7 +15,7 @@ namespace JudoPayDotNet.Models.Internal
         /// The CV2.
         /// </value>
         [DataMember(EmitDefaultValue = false)]
-        public string CV2 { get; set; }
+        public string Cv2 { get; set; }
         
         /// <summary>
         /// Gets or sets the Version.
@@ -35,7 +35,7 @@ namespace JudoPayDotNet.Models.Internal
             {
                 // This version can be used for all 3DS 2.x versions
                 Version = "2.0.0",
-                CV2 = externalModel.CV2,
+                Cv2 = externalModel.CV2,
                 PrimaryAccountDetails = !string.IsNullOrEmpty(externalModel.PrimaryAccountDetails?.AccountNumber) ? new PrimaryAccountDetailsModel()
                 {
                     PostCode = externalModel.PrimaryAccountDetails?.PostCode,

--- a/JudoPayDotNet/Models/Internal/InternalResumeThreeDSecureTwoModel.cs
+++ b/JudoPayDotNet/Models/Internal/InternalResumeThreeDSecureTwoModel.cs
@@ -12,7 +12,7 @@ namespace JudoPayDotNet.Models.Internal
         public InternalThreeDSecureTwoModel ThreeDSecure { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
-        public string CV2 { get; set; }
+        public string Cv2 { get; set; }
 
         [DataMember(EmitDefaultValue = false)]
         public PrimaryAccountDetailsModel PrimaryAccountDetails { get; set; }
@@ -25,7 +25,7 @@ namespace JudoPayDotNet.Models.Internal
                 {
                     MethodCompletion = externalModel.MethodCompletion
                 },
-                CV2 = externalModel.CV2,
+                Cv2 = externalModel.CV2,
                 PrimaryAccountDetails = !string.IsNullOrEmpty(externalModel.PrimaryAccountDetails?.AccountNumber) ? new PrimaryAccountDetailsModel()
                 {
                     PostCode = externalModel.PrimaryAccountDetails?.PostCode,

--- a/JudoPayDotNet/Models/RegisterCardModel.cs
+++ b/JudoPayDotNet/Models/RegisterCardModel.cs
@@ -25,8 +25,15 @@ namespace JudoPayDotNet.Models
         /// <value>
         /// The CV2.
         /// </value>
-        [DataMember(EmitDefaultValue = false)]
-        public string CV2 { get; set; }
+        public string CV2
+        {
+            get => Cv2;
+            set => Cv2 = value;
+        }
+
+        // This is marked as the DataMember to ensure the expected case is sent to the server API in Json - cv2
+        [DataMember(IsRequired = false)]
+        private string Cv2 { get; set; }
 
         /// <summary>
         /// Gets your payment reference.

--- a/JudoPayDotNet/Models/ThreeDSecureTwoPaymentModel.cs
+++ b/JudoPayDotNet/Models/ThreeDSecureTwoPaymentModel.cs
@@ -8,14 +8,22 @@ namespace JudoPayDotNet.Models
     [DataContract]
     public abstract class ThreeDSecureTwoPaymentModel : PaymentModel
     {
-        // Not explicitly associated with 3DS2, but moved here from PaymentModel to avoid the wallet payment types inheriting it
+        // Not explicitly associated with 3DS2, but moved here from PaymentModel to avoid the wallet payment types
+        // inheriting it.   This public accessor keeps the existing case but the DataMember is now the private Cv2
         /// <summary>
         /// The card CV2/CVV (3-4 digit validation code).
         /// </summary>
-        [DataMember(IsRequired = true)]
         // ReSharper disable InconsistentNaming
-        public string CV2 { get; set; }
+        public string CV2
+        {
+            get => Cv2;
+            set => Cv2 = value;
+        }
         // ReSharper restore InconsistentNaming
+
+        // This is marked as the DataMember to ensure the expected case is sent to the server API in Json - cv2
+        [DataMember(IsRequired = false)]
+        private string Cv2 { get; set; }
 
         /// <summary>
         /// The full card holder name.

--- a/JudoPayDotNetTests/Clients/ThreeDsTests.cs
+++ b/JudoPayDotNetTests/Clients/ThreeDsTests.cs
@@ -22,7 +22,7 @@ namespace JudoPayDotNetTests.Clients
 
             // Then version is always 2.0.0 and cv2 unchanged from external model
             Assert.AreEqual("2.0.0", internalComplete3Ds2Model.Version);
-            Assert.AreEqual(cv2FromMerchant, internalComplete3Ds2Model.CV2);
+            Assert.AreEqual(cv2FromMerchant, internalComplete3Ds2Model.Cv2);
         }
     }
 }


### PR DESCRIPTION
Public AP keeps it as CV2 to not break existing implementations, but attribute is sent in JSON to server as cv2 rather than cV2