### PR TITLE
Jr 8084 : update framework for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 4.2 Changes on 2024-TBD
+- TBD
+
 ## 4.1 Changes on 2023-09
 - Update Api-Version to 6.20
 - Add ShortUrl to WebPaymentResponseModel

--- a/JudoPayDotNet/JudoPayDotNet.csproj
+++ b/JudoPayDotNet/JudoPayDotNet.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <PropertyGroup Label="Package">
         <PackageId>JudoPay.Net</PackageId>
-        <Version>4.1</Version>
+        <Version>4.2</Version>
         <Authors>JudoPay</Authors>
         <Description>A .Net client for our JudoPay API, allowing you to quickly and easily process payments</Description>
         <Copyright>Copyright 2018</Copyright>

--- a/JudoPayDotNetCoreSampleApp/JudoPayDotNetCoreSampleApp.csproj
+++ b/JudoPayDotNetCoreSampleApp/JudoPayDotNetCoreSampleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>JudoPayDotNetCoreSampleApp</RootNamespace>
   </PropertyGroup>
 

--- a/JudoPayDotNetFrameworkSampleApp/App.config
+++ b/JudoPayDotNetFrameworkSampleApp/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/JudoPayDotNetFrameworkSampleApp/JudoPayDotNetFrameworkSampleApp.csproj
+++ b/JudoPayDotNetFrameworkSampleApp/JudoPayDotNetFrameworkSampleApp.csproj
@@ -8,10 +8,11 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>JudoPayDotNetFrameworkSampleApp</RootNamespace>
     <AssemblyName>JudoPayDotNetFrameworkSampleApp</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/JudoPayDotNetIntegrationTests/CheckCardTests.cs
+++ b/JudoPayDotNetIntegrationTests/CheckCardTests.cs
@@ -175,7 +175,7 @@ namespace JudoPayDotNetIntegrationTests
                         ExpiryDate = "",
                         YourConsumerReference = "UniqueRef",
                         YourPaymentReference = "UniqueRef"
-                    }, JudoModelErrorCode.Expiry_Date_Not_Supplied).SetName("ValidateRegisterCheckCardEmptyExpiryDate");
+                    }, JudoModelErrorCode.Expiry_Date_Not_Valid).SetName("ValidateRegisterCheckCardEmptyExpiryDate");
                 }
             }
         }

--- a/JudoPayDotNetIntegrationTests/CollectionsTests.cs
+++ b/JudoPayDotNetIntegrationTests/CollectionsTests.cs
@@ -35,7 +35,7 @@ namespace JudoPayDotNetIntegrationTests
                     yield return new TestCaseData(new CollectionModel
                     {
                         Amount = 1.20m
-                    }, JudoModelErrorCode.ReceiptId_Is_Invalid).SetName("ValidateCollectionMissingReceiptId"); // No ReceiptId_Not_Supplied as ReceiptId will be set to 0 as it is not null
+                    }, JudoModelErrorCode.ReceiptId_Not_Supplied).SetName("ValidateCollectionMissingReceiptId"); // No ReceiptId_Not_Supplied as ReceiptId will be set to 0 as it is not null
                     yield return new TestCaseData(new CollectionModel
                     {
                         ReceiptId = "-1",

--- a/JudoPayDotNetIntegrationTests/JudoPayDotNetIntegrationTests.csproj
+++ b/JudoPayDotNetIntegrationTests/JudoPayDotNetIntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>JudoPayDotNetIntegrationTests</AssemblyTitle>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -18,11 +18,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" />
-    <PackageReference Include="NUnit.Extension.VSProjectLoader" Version="3.8.0" />
-    <PackageReference Include="NUnit.Runners" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.17.0" />
+    <PackageReference Include="NUnit.Extension.VSProjectLoader" Version="3.9.0" />
+    <PackageReference Include="NUnit.Runners" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JudoPayDotNet\JudoPayDotNet.csproj" />

--- a/JudoPayDotNetIntegrationTests/PaymentTest.cs
+++ b/JudoPayDotNetIntegrationTests/PaymentTest.cs
@@ -320,7 +320,7 @@ namespace JudoPayDotNetIntegrationTests
             var firstFieldError = result.Error.ModelErrors.First();
             Assert.NotNull(firstFieldError);
             Assert.AreEqual(3250, firstFieldError.Code); // ThreeDSecure_Mpi_MissingFields
-            Assert.AreEqual("ThreeDSecureMpi.Cavv", firstFieldError.FieldName);
+            Assert.AreEqual("ThreeDSecureMpi.DsTransId", firstFieldError.FieldName);
             // Other errors are the same code for the other two invalid fields
         }
 

--- a/JudoPayDotNetIntegrationTests/RefundsTests.cs
+++ b/JudoPayDotNetIntegrationTests/RefundsTests.cs
@@ -183,7 +183,7 @@ namespace JudoPayDotNetIntegrationTests
                     yield return new TestCaseData(new RefundModel
                     {
                         Amount = 1.20m
-                    }, JudoModelErrorCode.ReceiptId_Is_Invalid).SetName("ValidateRefundMissingReceiptId"); // No ReceiptId_Not_Supplied as ReceiptId will be set to 0 as it is not null
+                    }, JudoModelErrorCode.ReceiptId_Not_Supplied).SetName("ValidateRefundMissingReceiptId"); // No ReceiptId_Not_Supplied as ReceiptId will be set to 0 as it is not null
                     yield return new TestCaseData(new RefundModel
                     {
                         ReceiptId = "-1",

--- a/JudoPayDotNetIntegrationTests/RegisterCardTests.cs
+++ b/JudoPayDotNetIntegrationTests/RegisterCardTests.cs
@@ -127,7 +127,7 @@ namespace JudoPayDotNetIntegrationTests
             var firstFieldError = result.Error.ModelErrors.First();
             Assert.NotNull(firstFieldError);
             Assert.AreEqual(3250, firstFieldError.Code); // ThreeDSecure_Mpi_MissingFields
-            Assert.AreEqual("ThreeDSecureMpi.Cavv", firstFieldError.FieldName);
+            Assert.AreEqual("ThreeDSecureMpi.DsTransId", firstFieldError.FieldName);
             // Other errors are the same code for the other two invalid fields
         }
     }

--- a/JudoPayDotNetIntegrationTests/SaveCardTests.cs
+++ b/JudoPayDotNetIntegrationTests/SaveCardTests.cs
@@ -225,7 +225,7 @@ namespace JudoPayDotNetIntegrationTests
                         CardNumber = "4976000000003436",
                         ExpiryDate = "",
                         YourConsumerReference = "UniqueRef"
-                    }, JudoModelErrorCode.Expiry_Date_Not_Supplied).SetName("ValidateSaveCardEmptyExpiryDate"); ;
+                    }, JudoModelErrorCode.Expiry_Date_Not_Valid).SetName("ValidateSaveCardEmptyExpiryDate"); ;
                 }
             }
         }

--- a/JudoPayDotNetIntegrationTests/VoidsTests.cs
+++ b/JudoPayDotNetIntegrationTests/VoidsTests.cs
@@ -35,7 +35,7 @@ namespace JudoPayDotNetIntegrationTests
                     yield return new TestCaseData(new VoidModel
                     {
                         Amount = 1.20m
-                    }, JudoModelErrorCode.ReceiptId_Is_Invalid).SetName("ValidateVoidMissingReceiptId"); // No ReceiptId_Not_Supplied as ReceiptId will be set to 0 as it is not null
+                    }, JudoModelErrorCode.ReceiptId_Not_Supplied).SetName("ValidateVoidMissingReceiptId"); // No ReceiptId_Not_Supplied as ReceiptId will be set to 0 as it is not null
                     yield return new TestCaseData(new VoidModel
                     {
                         ReceiptId = "-1",

--- a/JudoPayDotNetTests/JudoPayDotNetTests.csproj
+++ b/JudoPayDotNetTests/JudoPayDotNetTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>JudoPayDotNetTests</AssemblyTitle>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -16,11 +16,11 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" />
-    <PackageReference Include="NUnit.Extension.VSProjectLoader" Version="3.8.0" />
-    <PackageReference Include="NUnit.Runners" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.17.0" />
+    <PackageReference Include="NUnit.Extension.VSProjectLoader" Version="3.9.0" />
+    <PackageReference Include="NUnit.Runners" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JudoPayDotNet\JudoPayDotNet.csproj" />

--- a/JudoPayDotNetTests/JudoPaymentsFactoryTests.cs
+++ b/JudoPayDotNetTests/JudoPaymentsFactoryTests.cs
@@ -48,7 +48,7 @@ namespace JudoPayDotNetTests
         {
             var credentials = new Credentials("token", "secret");
             var expectedBaseAddress = "http://test.judopay.com/";
-            var client = JudoPaymentsFactory.Create(credentials, expectedBaseAddress, "4.1.0");
+            var client = JudoPaymentsFactory.Create(credentials, expectedBaseAddress, "4.2.0");
 
             Assert.That(client, Is.Not.Null);
             Assert.That(client.Connection.BaseAddress.ToString(), Is.EqualTo(expectedBaseAddress));


### PR DESCRIPTION
Update SDK version to 4.2
Update frameworks for test and sample projects to Net 7.0, Framework 4.8 to give supported versions available on new laptop
Update some integration tests to reflect minor changes now ACL is performing model validation